### PR TITLE
docs: add 27 Feb 2026 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to applescript-node are documented in this file.
 
 ## [Unreleased]
 
+### 27 February 2026
+
+#### Maintenance
+
+- Internal improvements and maintenance. No user-facing changes in this
+  period — updates were limited to CI workflow configuration,
+  build tooling, and code documentation. (#12, #28)
+
 ### 16 October 2025
 
 #### JSON Output and Data Structuring


### PR DESCRIPTION
## Summary

- Adds a 27 February 2026 maintenance entry to `CHANGELOG.md` documenting that PRs #12 and #28 contained no user-facing changes (CI workflow configuration, build tooling, and code documentation only)

## Test plan
- [x] No source code changed — changelog text only