### PR TITLE
ci(validate-bp): add strict pipe-character input validation and P5 tests

### DIFF
--- a/.github/workflows/validate-branch-protection.yml
+++ b/.github/workflows/validate-branch-protection.yml
@@ -40,6 +40,39 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate — no check names contain the pipe delimiter
+        run: |
+          # The pipe character (|) is used as the internal delimiter when
+          # sorting and comparing check name lists.  A name that itself
+          # contains | would be silently split into extra tokens, corrupting
+          # both the expected and actual lists and producing false match/mismatch.
+          #
+          # This step is a hard gate: if any name in required-checks.txt
+          # contains |, we fail immediately with a clear error before any
+          # comparison logic runs.
+
+          FAIL=0
+
+          echo "Scanning .github/required-checks.txt for pipe characters..."
+          while IFS= read -r line; do
+            # Skip blank / whitespace-only lines
+            [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+            if [[ "$line" == *"|"* ]]; then
+              echo "❌ Invalid check name contains '|': $line"
+              echo "   The pipe character is reserved as the internal delimiter."
+              echo "   GitHub Actions does not permit '|' in job names — remove it."
+              FAIL=$((FAIL + 1))
+            fi
+          done < .github/required-checks.txt
+
+          if [ "$FAIL" -eq 0 ]; then
+            echo "✅ No pipe characters found in required-checks.txt"
+          else
+            echo ""
+            echo "$FAIL invalid name(s) detected. Fix required-checks.txt before proceeding."
+            exit 1
+          fi
+
       - name: Regression test — pipe delimiter handles space-containing check names
         run: |
           # Regression test for the bug where `tr ' ' '\n'` shattered
@@ -180,6 +213,34 @@ jobs:
           else
             echo "  ⚠️  Pipe-name limitation appears to have changed — review delimiter choice."
           fi
+
+          # ── P5: Validator rejects | and accepts clean names ───────────────
+          echo ""
+          echo "P5  Strict validation — validator correctly classifies names"
+
+          validate_name() {
+            # Returns 0 (clean) or 1 (contains pipe) — mirrors the gate step logic
+            [[ "$1" == *"|"* ]] && return 1 || return 0
+          }
+
+          # Must reject: names containing |
+          PIPE_CASES=("a|b" "test (20)|test (22)" "check|1" "|leading" "trailing|")
+          for bad in "${PIPE_CASES[@]}"; do
+            if ! validate_name "$bad"; then
+              pass "rejects '$bad'"
+            else
+              fail "should reject '$bad'" "validator returned clean for a pipe-containing name"
+            fi
+          done
+
+          # Must accept: all atoms in the test set (none contain |)
+          for name in "${ATOMS[@]}"; do
+            if validate_name "$name"; then
+              pass "accepts '$name'"
+            else
+              fail "should accept '$name'" "validator wrongly rejected a pipe-free name"
+            fi
+          done
 
           # ── Summary ───────────────────────────────────────────────────────
           echo ""


### PR DESCRIPTION
## Summary

Adds a hard-gate validation step that rejects any check name containing `|` before any comparison logic runs, plus a P5 property test verifying the validator correctly classifies pipe-containing and pipe-free names.

## What changed

### New step: *"Validate — no check names contain the pipe delimiter"*

Runs immediately after checkout, before all regression tests and derivation steps. Scans every non-blank line of `.github/required-checks.txt` using `[[ "$line" == *"|"* ]]` and exits 1 with a named diagnostic if any match. Without this gate, a pipe-containing name would silently corrupt the token count in the sort-pipe-join pipeline — producing either a false match or a false mismatch with no clear error.

**Example failure output:**
```
❌ Invalid check name contains '|': test | verify
   The pipe character is reserved as the internal delimiter.
   GitHub Actions does not permit '|' in job names — remove it.
1 invalid name(s) detected. Fix required-checks.txt before proceeding.
```

### New P5 property in the fuzz test step

| Sub-case | Input | Expected |
|---|---|---|
| Reject `"a\|b"` | pipe mid-name | validator returns 1 |
| Reject `"test (20)\|test (22)"` | pipe separator | validator returns 1 |
| Reject `"\|leading"` | leading pipe | validator returns 1 |
| Reject `"trailing\|"` | trailing pipe | validator returns 1 |
| Accept all 10 atoms | none contain pipe | validator returns 0 |

**Total assertions: 116** (up from 101 — +5 reject cases, +10 accept cases).

## Why

The P4 documented limitation noted that `|` in a name breaks the delimiter. This PR graduates that from a comment to an enforced invariant: the workflow now fails fast with a named step and actionable message rather than producing a confusing token-count mismatch downstream.

## Risk / Rollout

Zero runtime risk — pure bash string matching (`[[ == *|* ]]`), no external calls, `contents: read` only. Current `required-checks.txt` contains no pipe characters so this gate will always pass on main.