### PR TITLE
docs: add 28 Feb 2026 changelog entry for PRs #30–#35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to applescript-node are documented in this file.
 
 ## [Unreleased]
 
+### 28 February 2026
+
+#### Maintenance
+
+- Internal improvements and maintenance. No user-facing changes in this
+  period — updates were limited to CI hardening, branch protection
+  configuration, and build tooling. (#30, #31, #32, #33, #34, #35)
+
 ### 27 February 2026
 
 #### Maintenance


### PR DESCRIPTION
## Summary

Adds the 28 February 2026 CHANGELOG entry covering the six PRs merged today.

## What changed

- **`CHANGELOG.md`**: new `### 28 February 2026` section under `[Unreleased]`

## Classification

All six PRs (#30–#35) are internal changes with no user-facing impact:

| PR | Description | Category |
|---|---|---|
| #30 | Coverage hardening, script stubs, ESLint fix | Tests / build |
| #31 | Branch protection validation workflow | CI |
| #32 | Regression test: space-containing check names | CI |
| #33 | Edge-case regression tests | CI |
| #34 | Property-based fuzz test | CI |
| #35 | Pipe-character input validation and P5 tests | CI |

Per the changelog guidelines, CI, tests, build tooling, and internal documentation are excluded. The entry correctly uses the minimal maintenance notice.

## Testing

- `CHANGELOG.md` format matches the existing 27 February entry exactly
- British English used throughout
- PR numbers included for traceability