### PR TITLE
docs: include PR #36 in 28 Feb 2026 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to applescript-node are documented in this file.
 
 - Internal improvements and maintenance. No user-facing changes in this
   period — updates were limited to CI hardening, branch protection
-  configuration, and build tooling. (#30, #31, #32, #33, #34, #35)
+  configuration, build tooling, and release documentation.
+  (#30, #31, #32, #33, #34, #35, #36)
 
 ### 27 February 2026
 


### PR DESCRIPTION
## Summary

- Adds PR #36 to the 28 February 2026 changelog entry alongside #30–#35
- Updates the description to mention "release documentation" (which is what #36 covered)
- No user-facing changes; this is a documentation housekeeping commit

## What changed

- `CHANGELOG.md`: extended the `(#30, #31, #32, #33, #34, #35)` reference to `(#30, #31, #32, #33, #34, #35, #36)` and added "release documentation" to the maintenance description

## Why

PR #36 merged the first changelog entry for 28 Feb but was itself not listed in that entry. This PR closes the gap for completeness and traceability.

## Testing

- `pnpm verify` passed (lint → 801 tests → build)
- No functional changes; changelog is plain text

## Risk / Rollout

- Low risk; documentation-only change
- No code paths affected