### PR TITLE
docs(changelog): backfill missing entries and fix PR references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to applescript-node are documented in this file.
 - Internal improvements and maintenance. No user-facing changes in this
   period — updates were limited to CI hardening, branch protection
   configuration, build tooling, and release documentation.
-  (#30, #31, #32, #33, #34, #35, #36)
+  (#30, #31, #32, #33, #34, #35, #36, #37)
 
 ### 27 February 2026
 
@@ -19,7 +19,25 @@ All notable changes to applescript-node are documented in this file.
 
 - Internal improvements and maintenance. No user-facing changes in this
   period — updates were limited to CI workflow configuration,
-  build tooling, and code documentation. (#12, #28)
+  build tooling, and code documentation. (#12, #28, #29)
+
+### 31 January 2026
+
+#### Bug Fixes
+
+- Fixed TypeScript type definitions failing to regenerate after build,
+  ensuring `.d.ts` files are always included in published npm
+  packages (#19)
+- Updated `fast-xml-parser` to resolve a security vulnerability
+  (GHSA-37qj-frw5-hhjh) (#19)
+
+### 30 November 2025
+
+#### Documentation
+
+- Added documentation website with Getting Started, Builder API,
+  Data Extraction, and API Reference sections (#11)
+- Rewrote README for improved clarity and scannability (#11)
 
 ### 16 October 2025
 


### PR DESCRIPTION
## Summary

Release-readiness sweep found four inconsistencies in `CHANGELOG.md`:

1. **PR #37 missing from 28 Feb 2026 references** — #37 merged on 28 Feb but was not listed alongside #36
2. **PR #29 missing from 27 Feb 2026 references** — inconsistent with 28 Feb listing its own changelog PRs (#36, #37)
3. **31 Jan 2026 (v1.0.1) not covered** — the release fixed two user-facing issues with no changelog entry:
   - TypeScript type definitions failing to regenerate after build (`build:types` script)
   - `fast-xml-parser` security patch (GHSA-37qj-frw5-hhjh)
4. **30 Nov 2025 not covered** — PR #11 added a Fumadocs documentation website and rewrote the README, both user-facing

## What changed

- `CHANGELOG.md`: added four changes — two reference additions and two new dated entries

## Why

A CHANGELOG is the primary contract with users upgrading between releases. The missing security advisory (GHSA-37qj-frw5-hhjh) and broken type definitions from v1.0.1 are exactly the kind of silent regressions users need visibility on.

## Testing

- `pnpm verify` passed (lint → 801 tests → build)
- Documentation-only change; no code paths affected

## Risk / Rollout

- Low risk; CHANGELOG is plain text with no functional impact
- All PR numbers verified against `gh pr list --state merged`