### PR TITLE
ci(changelog): add automated changelog consistency validation

### DIFF
--- a/.github/changelog-excluded-prs.txt
+++ b/.github/changelog-excluded-prs.txt
@@ -1,0 +1,25 @@
+# PRs intentionally excluded from CHANGELOG.md coverage.
+# One PR number per line. Lines starting with # are comments.
+#
+# Add a PR here when it is purely internal (CI, tests, refactoring,
+# internal documentation) and has no user-facing impact, OR when it
+# is the terminal changelog-update PR for a release period (to avoid
+# infinite regress where the changelog PR must list itself).
+#
+# Dependabot PRs are excluded automatically by the workflow and do
+# not need to be listed here.
+
+# Pre-publish internal QA (refactoring, JSDoc, lint rules)
+9
+
+# Internal developer guidelines added to CLAUDE.md only
+10
+
+# Test coverage improvements and code quality (no user-facing changes)
+20
+
+# Terminal changelog backfill PR for 28 Feb 2026 series
+38
+
+# Changelog consistency validation workflow (this CI addition)
+39

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -1,0 +1,132 @@
+name: Validate Changelog
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - CHANGELOG.md
+      - .github/changelog-excluded-prs.txt
+      - .github/workflows/validate-changelog.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - CHANGELOG.md
+      - .github/changelog-excluded-prs.txt
+      - .github/workflows/validate-changelog.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate-references:
+    name: Validate — PR references exist and dates are valid
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate all #N references are merged PRs
+        run: |
+          FAIL=0
+          PR_NUMS=$(grep -oE '#[0-9]+' CHANGELOG.md | grep -oE '[0-9]+' | sort -nu)
+
+          for num in $PR_NUMS; do
+            STATE=$(gh pr view "$num" --json state --jq '.state' 2>/dev/null \
+              || echo "NOT_FOUND")
+            if [[ "$STATE" != "MERGED" ]]; then
+              echo "FAIL: CHANGELOG.md references #$num but it is not a merged PR (state: $STATE)"
+              FAIL=$((FAIL + 1))
+            else
+              echo "OK: #$num is a valid merged PR"
+            fi
+          done
+
+          if [ "$FAIL" -gt 0 ]; then
+            echo ""
+            echo "Fix: Remove or correct the invalid PR reference(s) in CHANGELOG.md."
+            exit 1
+          fi
+
+      - name: Validate dated sections are not in the future
+        run: |
+          FAIL=0
+          TODAY=$(date +%s)
+
+          while IFS= read -r line; do
+            if [[ "$line" =~ ^###\ ([0-9]+)\ ([A-Za-z]+)\ ([0-9]{4})$ ]]; then
+              DAY="${BASH_REMATCH[1]}"
+              MONTH="${BASH_REMATCH[2]}"
+              YEAR="${BASH_REMATCH[3]}"
+              SECTION_TS=$(date -d "$DAY $MONTH $YEAR" +%s 2>/dev/null || echo "INVALID")
+
+              if [[ "$SECTION_TS" == "INVALID" ]]; then
+                echo "WARNING: Cannot parse date: $DAY $MONTH $YEAR — check spelling"
+                FAIL=$((FAIL + 1))
+              elif [[ "$SECTION_TS" -gt "$TODAY" ]]; then
+                echo "FAIL: Future date in CHANGELOG.md: $DAY $MONTH $YEAR"
+                FAIL=$((FAIL + 1))
+              else
+                echo "OK: $DAY $MONTH $YEAR"
+              fi
+            fi
+          done < CHANGELOG.md
+
+          [ "$FAIL" -eq 0 ] || exit 1
+
+  validate-coverage:
+    name: Validate — merged PRs covered in changelog
+    runs-on: ubuntu-latest
+    # Coverage check runs after merge so the changelog PR covering
+    # these changes can land before the check fires.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate non-Dependabot PRs appear in CHANGELOG.md or exclusion list
+        run: |
+          FAIL=0
+          CHANGELOG=$(cat CHANGELOG.md)
+          EXCLUDED=$(grep -v '^#' .github/changelog-excluded-prs.txt 2>/dev/null \
+            | grep -E '^[0-9]+$' | sort -n || true)
+
+          # Look back 90 days to catch historical gaps
+          CUTOFF=$(date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          RECENT_PRS=$(gh pr list --state merged --limit 200 \
+            --json number,author,mergedAt,title \
+            | jq -r --arg cutoff "$CUTOFF" \
+              '.[] | select(
+                (.author.login | contains("dependabot") | not) and
+                .mergedAt > $cutoff
+              ) | [.number, .title] | @tsv')
+
+          if [[ -z "$RECENT_PRS" ]]; then
+            echo "No recent non-Dependabot PRs found within the 90-day window."
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r num title; do
+            [[ -z "$num" ]] && continue
+
+            if echo "$CHANGELOG" | grep -qE "#${num}([^0-9]|$)"; then
+              echo "OK: PR #$num covered in CHANGELOG.md"
+              continue
+            fi
+
+            if echo "$EXCLUDED" | grep -qE "^${num}$"; then
+              echo "SKIP: PR #$num in exclusion list (intentionally omitted)"
+              continue
+            fi
+
+            echo "FAIL: PR #$num not in CHANGELOG.md or exclusion list"
+            FAIL=$((FAIL + 1))
+          done <<< "$RECENT_PRS"
+
+          if [ "$FAIL" -gt 0 ]; then
+            echo ""
+            echo "Fix: Add the PR(s) to a dated entry in CHANGELOG.md, or add the PR"
+            echo "number to .github/changelog-excluded-prs.txt if intentionally omitted."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a CI workflow that enforces changelog completeness and link integrity going forward, preventing the kind of historical gaps found in today's release-readiness sweep.

## What changed

- **`.github/workflows/validate-changelog.yml`** — new workflow with two jobs:
  - `validate-references` (runs on PR + push to main): verifies every `#N` in `CHANGELOG.md` is a real merged PR; rejects future-dated section headers
  - `validate-coverage` (runs on push to main only): verifies every non-Dependabot PR merged in the last 90 days appears in `CHANGELOG.md` or the exclusion list
- **`.github/changelog-excluded-prs.txt`** — committed source of truth for PRs intentionally omitted from the changelog (internal CI, tests, terminal changelog-update PRs)

## Why

Today's sweep found 4 coverage gaps: PRs #9, #10, #20 (internal, pre-publish), #29/#37/#38 (changelog housekeeping) and missing entries for Nov 2025 and Jan 2026. This workflow catches those gaps automatically before they age into historical debt.

## Design decisions

- **Coverage check on push-to-main only** — avoids the bootstrap paradox where the changelog PR for a batch of work must already be in `CHANGELOG.md` before it merges
- **Exclusion list** (`.github/changelog-excluded-prs.txt`) — mirrors the `.github/required-checks.txt` pattern; explicitly documents intentional omissions rather than silently passing
- **90-day window** — wide enough to catch historical gaps during the first run while naturally expiring old entries
- **Dependabot filtered by author** — no need to add each dependency bump to the exclusion list

## Testing

- `pnpm verify` passed (lint → 801 tests → build)
- Workflow validated against current CHANGELOG.md locally: all existing references are merged PRs; all recently merged PRs are either in CHANGELOG.md or in the exclusion list

## Risk / Rollout

- Low risk; does not affect source code or the library's public API
- Exclusion list pre-seeds PR #39 (this PR) so the first post-merge coverage run passes immediately