### PR TITLE
docs(changelog): add #21 and #40 to 28 Feb 2026 maintenance entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to applescript-node are documented in this file.
 
 - Internal improvements and maintenance. No user-facing changes in this
   period — updates were limited to CI hardening, branch protection
-  configuration, build tooling, and release documentation.
-  (#30, #31, #32, #33, #34, #35, #36, #37)
+  configuration, build tooling, release documentation, and developer
+  guidance. (#21, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39,
+  #40)
 
 ### 27 February 2026
 


### PR DESCRIPTION
## Summary

- Extends the existing 28 Feb 2026 Maintenance entry to include PR #21 (complex README usage examples + template literal CI fix) and PR #40 (CI debugging and template literal guidance in CLAUDE.md)
- Both are internal documentation changes with no user-facing impact
- Adds "developer guidance" to the prose description to accurately cover CLAUDE.md updates

## Test plan

- [ ] Changelog CI validator passes (both PRs now appear in CHANGELOG.md)
- [ ] No new exclusion list entries needed (PRs referenced directly in the entry)