### PR TITLE
fix(pkg): move types condition first in exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

- Reorders the `exports` field so `"types"` comes **before** `"import"` and `"require"`
- Fixes a tsup build warning: `"types" will never be used as it comes after both "import" and "require"`
- Ensures TypeScript consumers using `moduleResolution: bundler` or `node16`/`nodenext` resolve to `dist/index.d.ts` directly via the exports map

## Background

This was introduced in v1.0.3 (#43). The exports field was added with the conditions in the wrong order. TypeScript evaluates export conditions in declaration order — `"types"` must come first to be selected when TypeScript resolves the package.

## Test plan

- [ ] CI passes (lint, typecheck, tests)
- [ ] Build produces valid dist/ with no tsup warnings about `"types"`