### PR TITLE
test(pkg): assert exports map keeps types as first condition

### DIFF
--- a/src/package-manifest.test.ts
+++ b/src/package-manifest.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const pkgPath = resolve(process.cwd(), 'package.json');
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+  exports?: Record<string, Record<string, string>>;
+  types?: string;
+  main?: string;
+  module?: string;
+};
+
+describe('package.json manifest', () => {
+  describe('exports map', () => {
+    it('has a "." entry in exports', () => {
+      expect(pkg.exports).toBeDefined();
+      expect(pkg.exports?.['.']).toBeDefined();
+    });
+
+    it('has "types" as the first condition in exports["."]', () => {
+      const entry = pkg.exports?.['.'];
+      expect(entry).toBeDefined();
+      const firstKey = Object.keys(entry ?? {})[0];
+      expect(firstKey).toBe('types');
+    });
+
+    it('exports["."].types points to the declaration file', () => {
+      expect(pkg.exports?.['.']?.types).toBe('./dist/index.d.ts');
+    });
+
+    it('exports["."].import points to the ESM bundle', () => {
+      expect(pkg.exports?.['.']?.import).toBe('./dist/index.mjs');
+    });
+
+    it('exports["."].require points to the CJS bundle', () => {
+      expect(pkg.exports?.['.']?.require).toBe('./dist/index.js');
+    });
+
+    it('exports["."] contains exactly types, import, require conditions', () => {
+      const keys = Object.keys(pkg.exports?.['.'] ?? {});
+      expect(keys).toEqual(['types', 'import', 'require']);
+    });
+  });
+
+  describe('top-level type fields', () => {
+    it('has a top-level "types" field for legacy TypeScript resolution', () => {
+      expect(pkg.types).toBe('./dist/index.d.ts');
+    });
+
+    it('has a top-level "main" field for legacy CJS consumers', () => {
+      expect(pkg.main).toBe('./dist/index.js');
+    });
+
+    it('has a top-level "module" field for legacy bundler ESM resolution', () => {
+      expect(pkg.module).toBe('./dist/index.mjs');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/package-manifest.test.ts` to guard the `exports` map ordering in `package.json`
- Prevents a recurrence of the v1.0.3 regression (#43) where `"types"` was listed after `"import"`/`"require"`, making it unreachable for TypeScript consumers using `moduleResolution: bundler`/`node16`/`nodenext`
- 9 new tests covering: exports entry existence, `types`-first ordering, all three condition paths, and the top-level `types`/`main`/`module` fields

## Why this matters

TypeScript evaluates `exports` conditions in declaration order. If `"import"` precedes `"types"`, TypeScript matches `"import"` first in ESM contexts and must hunt for type declarations separately rather than resolving directly to `dist/index.d.ts`. The new test makes this order a hard invariant caught at CI time.

## Test plan

- [ ] `pnpm test` passes (810 tests across 23 files)
- [ ] `pnpm lint` passes (no non-null assertions, no type errors)