### PR TITLE
docs: compact CLAUDE.md under size thresholds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1173 +1,147 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Project Overview
 
-**applescript-node** is a production-ready Node.js library providing a type-safe interface for executing AppleScript and JavaScript through macOS's `osascript`. Bridges Node.js applications and macOS automation.
+**applescript-node** — production-ready Node.js library for type-safe AppleScript/JavaScript execution via macOS `osascript`. ESM-first, Promise-based, fluent builder API.
 
-### Core Purpose
-
-The library enables developers to:
-
-- Automate macOS applications from Node.js
-- Build automation workflows with fluent API
-- Create system administration tools for macOS
-- Develop testing frameworks for macOS applications
-- Integrate macOS scripting into web applications and services
-
-### Key Value Propositions
-
-- **Type Safety**: Full TypeScript support
-- **Developer Experience**: Fluent builder API, intuitive and discoverable
-- **Production Ready**: Extensive testing, error handling
-- **Modern Architecture**: Promise-based, async/await, ESM-first
-- **Comprehensive Coverage**: Complete macOS automation
-
-**Platform requirement**: macOS-only, requires `osascript` (macOS 10.10+).
+**Platform**: macOS-only, requires `osascript` (macOS 10.10+).
 
 ## Build and Development Commands
 
-### Building
+- `pnpm build` — Full build (JS + types)
+- `pnpm build:js` — Build JS with tsup
+- `pnpm build:types` — Generate .d.ts (includes `--force` flag)
+- `pnpm dev` — Watch mode
+- `pnpm test` — Run all tests (Vitest)
+- `pnpm test:coverage` — Coverage report (80% minimum)
+- `pnpm lint` — Type check + ESLint
+- `pnpm format:fix` — Format and auto-fix
+- `pnpm typecheck` — Type check without emitting
+- `pnpm verify` — Lint, test, and build
+- `pnpm examples` — Run all examples
 
-- `pnpm build` - Full build (JavaScript + types)
-- `pnpm build:js` - Build JavaScript with tsup
-- `pnpm build:types` - Generate TypeScript declarations (includes `--force` flag to ensure regeneration after tsup cleans dist/)
-- `pnpm dev` - Watch mode for development
+**DON'T** remove `rm -f tsconfig.build.tsbuildinfo` from `build:types`. Without it, tsc skips emitting .d.ts after tsup cleans dist/.
 
-**DON'T** remove the `rm -f tsconfig.build.tsbuildinfo` from `build:types`. The tsup `clean: true` option wipes the dist/ folder, but tsc's incremental build cache (`tsconfig.build.tsbuildinfo`) persists in the project root. Without deleting this cache, tsc believes the .d.ts files are "up to date" and skips emitting them, causing npm packages to ship without type definitions.
-
-### Testing
-
-- `pnpm test` - Run all tests with Vitest
-- `pnpm test:watch` - Run tests in watch mode
-- `pnpm test:coverage` - Generate coverage report (80% minimum)
-
-### Code Quality
-
-- `pnpm lint` - Type check with tsc and lint with ESLint
-- `pnpm format` - Format code with Prettier
-- `pnpm format:fix` - Format and auto-fix lint issues
-- `pnpm typecheck` - Type check without emitting
-- `pnpm verify` - Run lint, test, and build
-
-### Running Examples
-
-- `pnpm run example:basic` - Basic script execution
-- `pnpm run example:builder` - Fluent builder API
-- `pnpm run example:compile` - Script compilation
-- `pnpm run example:languages` - Language information
-- `pnpm run example:list-apps` - List running applications
-- `pnpm run example:windows` - Window management
-- `pnpm examples` - Run all examples
+**DON'T** add ultracite to lint-staged — deprecated biome rules cause failures. ESLint handles linting.
 
 ## Architecture
 
 ### Core Modules
 
-1. **executor.ts** (`ScriptExecutor`)
-
-   - Primary execution engine for AppleScript/JavaScript
-   - Handles string and file-based execution
-   - Manages `osascript` flags and output formatting
-   - Uses Node.js `child_process.exec` with promisified interface
-   - Error handling: Uses `extractErrorInfo()` helper to capture stderr, exit codes from various error types (Error, ErrnoException)
-   - Output processing: Handles human-readable vs raw output
-   - Security: Properly escapes single quotes in scripts
-
-2. **builder.ts** (`AppleScriptBuilder`)
-
-   - Fluent API for constructing commands
-   - Block stack management: Tracks nested blocks
-   - Syntax validation: Ensures blocks opened/closed
-   - Automatic indentation: Maintains formatting
-   - Method chaining: Returns `ScriptBuilder` for fluent interface
-   - Value formatting: Handles data types
-   - Block validation prevents malformed scripts
-
-3. **compiler.ts** (`ScriptCompiler`)
-
-   - Compilation to `.scpt` or `.scptd` format
-   - Uses `osacompile` with flags
-   - Stay-open applications: Creates persistent apps
-   - Bundle creation: Supports `.scptd` format
-   - Execute-only compilation: Creates protected scripts
-   - Startup screen support: Adds splash screens
-
-4. **decompiler.ts** (`ScriptDecompiler`)
-
-   - Reverse compilation of `.scpt` files
-   - Uses `osadecompile`
-   - Error handling: Manages decompilation failures
-   - Source recovery: Extracts script text
-
-5. **languages.ts** (`LanguageManager`)
-
-   - OSA language discovery and querying
-   - Uses `osalang` to enumerate languages
-   - Capability parsing: Extracts features
-   - Language info: Provides information
-   - Default language detection: Identifies system default, returns fallback AppleScript object when no languages installed
-
-6. **types.ts** (`TypeDefinitions`)
-   - Central type system
-   - Key interfaces: `ScriptBuilder`, `ScriptExecutionResult`, `OsaScriptOptions`
-   - AppleScript types: `AppleScriptValue`, `AppleScriptPrimitive`
-   - System types: `WindowInfo` (per-app windows), `ProcessInfo`, `ApplicationTarget`
-   - Configuration types: `CompileOptions`, `OsaLanguageInfo`
-   - Error types: `ScriptError` with error information
-   - **Note**: `WindowInfo` in types.ts differs from `sources/windows.ts` - types.ts is for per-app windows (builder methods), sources/windows.ts is for system-wide window enumeration (includes `app` field)
+1. **executor.ts** — Primary execution engine. Uses `child_process.exec`, `extractErrorInfo()` for stderr/exit codes, escapes single quotes.
+2. **builder.ts** — Fluent API with block stack management, syntax validation, auto-indentation, method chaining.
+3. **compiler.ts** — Compilation to `.scpt`/`.scptd` via `osacompile`. Stay-open apps, bundles, execute-only.
+4. **decompiler.ts** — Reverse compilation via `osadecompile`.
+5. **languages.ts** — OSA language discovery via `osalang`. Fallback AppleScript object when no languages installed.
+6. **types.ts** — Central type system. Key: `ScriptBuilder`, `ScriptExecutionResult`, `OsaScriptOptions`, `AppleScriptValue`, `CompileOptions`. **Note**: `WindowInfo` in types.ts (per-app) differs from `sources/windows.ts` (system-wide, includes `app` field).
 
 ### Build System
 
-- **tsup** for JavaScript bundling
-- **TypeScript** compiler for type declarations
-- **Module system**: NodeNext
-- **Output**: `dist/` with dual package exports
-- **Bundling**: Rollup-based with tree shaking
-- **Source maps**: Generated
-- **Package exports**: Conditional exports
+tsup for JS bundling, TypeScript for declarations, NodeNext modules, `dist/` with dual package exports, source maps.
 
-### Testing Strategy
+### Testing
 
-- **Vitest** with node environment
-- **Coverage thresholds**: 80% minimum
-- **Test organization**: Co-located test files (\*.test.ts)
-- **Execution**: Single-threaded with randomized sequence
-- **Mocking**: Comprehensive mocking
-- **Integration tests**: Real `osascript` execution
-- **Test categories**:
-  - Unit tests for methods and classes
-  - Integration tests for workflow validation
-  - Error handling tests for failure scenarios
-  - Type safety tests for TypeScript compliance
+Vitest, 80% coverage minimum, co-located `.test.ts` files, single-threaded randomized. Unit tests mock `child_process.exec`, integration tests use real `osascript`.
 
-### Code Quality Standards
+### Code Quality
 
-- **ESLint v9** with flat config
-- **TypeScript strict mode**
-- **Prettier** for formatting
-- **Key rules**:
-  - Consistent type imports
-  - No explicit `any` types
-  - Unused variables with `_` prefix - **but verify they're truly unused**. Parameters prefixed with `_` that should actually be used indicate incomplete implementations (e.g., `_provideSuggestions` in validator.ts was meant to control suggestion generation but was ignored)
-  - Array types use simple syntax
-  - Interfaces preferred over type aliases
-  - Consistent naming
-  - Maximum line length 100
-  - Trailing commas
-  - **Use `??` not `||`** for default values with potentially falsy values (ESLint: `@typescript-eslint/prefer-nullish-coalescing`). Common locations: `sources/system.ts`, `sources/windows.ts`
-  - **Avoid `String()` on objects** - check `typeof value === 'string'` first when parsing JSON output (ESLint: `@typescript-eslint/no-base-to-string`)
-  - **Use `includes()` over regex for simple substring checks** (ESLint: `@typescript-eslint/prefer-includes`). Example: `str.includes(' to ')` not `/ to /.test(str)`
+ESLint v9 flat config, TypeScript strict, Prettier. Key rules:
 
-### Pre-commit Quality Gates
+- `??` not `||` for defaults (`@typescript-eslint/prefer-nullish-coalescing`)
+- No `String()` on objects — check `typeof` first (`@typescript-eslint/no-base-to-string`)
+- `includes()` over regex for substrings (`@typescript-eslint/prefer-includes`)
+- `_` prefix for unused vars — but verify they're truly unused
+- Interfaces over type aliases, consistent type imports, max line 100
 
-**husky** + **lint-staged** for quality checks:
+### Pre-commit (husky + lint-staged)
 
-- **ESLint + Prettier** on TypeScript files
-- **Type checking** with `tsc --noEmit --skipLibCheck`
-- **Vitest execution** on test files
-- **Type declaration build** verification
-- **Staged file processing** for performance
-- **Automatic fixes** where possible
-
-**DON'T** add ultracite back to lint-staged. The `pnpm dlx ultracite fix` command was removed because ultracite's extended biome configuration contains deprecated rules (`useConsistentTypeDefinitions`, `noSecrets`, `noNonNullAssertedOptionalChain`) that cause validation failures with newer biome versions (2.2.6+). ESLint already handles linting for this project.
+ESLint+Prettier on TS files, `tsc --noEmit --skipLibCheck`, Vitest on test files, type declaration build verification.
 
 ## Key Implementation Patterns
 
-### Script Building with Block Stack
+### Block Stack
 
-`AppleScriptBuilder` maintains block stack for AppleScript syntax:
+Block types: `tell`, `if`, `repeat`, `considering`, `ignoring`, `using`, `with`, `try`, `on`. Opening methods push, `end()` pops and validates, `build()` ensures all closed.
 
-- **Block types**: `tell`, `if`, `repeat`, `considering`, `ignoring`, `using`, `with`, `try`, `on`
-- **Stack management**: Opening methods push blocks, `end()` pops and validates
-- **Nesting validation**: Ensures block hierarchy
-- **Context awareness**: `then()` and `else()` validate inside `if`
-- **Build validation**: `build()` ensures all blocks closed
-- **Inline statement detection**: `loadFromScript()` distinguishes inline vs multi-line statements:
-  - Inline tell: `tell app "X" to activate` (has `to` NOT followed by `tell`) - no block push
-  - Nested tell: `tell app "X" to tell process "Y"` (has ` to tell`) - pushes block
-  - Inline if: `if x then return y` (has `then` followed by content) - no block push
+**Inline detection** in `loadFromScript()`:
 
-Example of proper block usage:
+- Inline tell: `tell app "X" to activate` (has `to` NOT followed by `tell`) — no push
+- Nested tell: `tell app "X" to tell process "Y"` (has ` to tell`) — pushes
+- Inline if: `if x then return y` (has `then` + content) — no push
 
-```typescript
-createScript()
-  .tell('Finder') // Pushes 'tell' block
-  .if('count of windows > 0') // Pushes 'if' block
-  .then() // Validates inside 'if'
-  .closeWindow()
-  .else() // Validates inside 'if'
-  .displayDialog('No windows')
-  .end() // Pops 'if' block
-  .end() // Pops 'tell' block
-  .build(); // Validates all blocks closed
-```
+### Explicit Endings
 
-### Command Execution Pattern
+`endif()`, `endrepeat()`, `endtry()`, `endtell()`, `endon()`, `endconsidering()`, `endignoring()`, `endusing()`, `endwith()` — validate block type match at runtime.
 
-Script execution follows pattern through `ScriptExecutor`:
+### Convenience Helpers
 
-1. **Flag building**: Convert options to `osascript` flags
-2. **Script escaping**: Escape single quotes and special characters
-3. **Command construction**: Build `osascript` command
-4. **Execution**: Use `child_process.exec` with promisified interface
-5. **Result processing**: Parse stdout/stderr into result
-6. **Error handling**: Capture exit codes and error messages
+- `ifThen(condition, callback)` / `ifThenElse(condition, thenCb, elseCb)` — auto-close blocks
+- `tryCatch(tryCb, catchCb)` / `tryCatchError(tryCb, errorVar, catchCb)` — auto-close with optional error variable
 
-### Type Safety Architecture
+### setEndRecord
 
-Type safety through layers:
+Combines property extraction and record creation. Form 1: direct expressions. Form 2: source object shorthand (appends "of source").
 
-- **Generic return types**: `runScript<T>()` for typed output
-- **Method chaining**: Builder methods return `ScriptBuilder`
-- **Options interfaces**: Typed configuration objects
-- **Union types**: For modifiers, window arrangements, languages
-- **AppleScript value types**: Proper typing for data structures
-- **Error types**: Structured error information
+### setIfExists / setEndIfExists
 
-## API Design Philosophy
+Handle optional properties with existence check, type conversion (`asType`), and defaults. Generates if-then-else blocks.
 
-### Fluent Builder Pattern
+### mapToJson with PropertyExtractor
 
-Fluent builder pattern:
-
-- **Method chaining**: Each method returns builder
-- **Contextual methods**: Grouped by functionality
-- **Progressive disclosure**: Simple methods for common tasks
-- **Discoverability**: IntelliSense suggestions
-
-### Error Handling Strategy
-
-Error handling:
-
-- **Execution errors**: Captured from `osascript` stderr
-- **Validation errors**: Block stack validation
-- **Type errors**: TypeScript compile-time prevention
-- **Runtime errors**: Graceful handling of failures
-- **Error context**: Error messages
-
-### Performance Considerations
-
-Optimized:
-
-- **Lazy evaluation**: Scripts built when `build()` called
-- **Efficient execution**: Direct `osascript` spawning
-- **Memory management**: Minimal object creation
-- **Caching**: Language information and capabilities cached
-- **Streaming**: Large outputs handled efficiently
-
-## Common Use Cases and Patterns
-
-### Application Automation
-
-```typescript
-// Launch and control apps
-const script = createScript()
-  .tell('Finder')
-  .activate()
-  .tell('System Events')
-  .keystroke('n', ['command']) // New window
-  .delay(1)
-  .keystroke('Hello World')
-  .end()
-  .end();
-```
-
-### Window Management
-
-```typescript
-// Window operations
-const script = createScript()
-  .tell('Finder')
-  .getWindowInfo('Finder', 'Downloads')
-  .moveWindow('Finder', 'Downloads', 100, 100)
-  .resizeWindow('Finder', 'Downloads', 800, 600)
-  .end();
-```
-
-### System Integration
-
-```typescript
-// System operations
-const script = createScript()
-  .tell('System Events')
-  .getRunningApplications()
-  .doShellScript('ls -la', true) // With admin privileges
-  .end();
-```
-
-### Error Recovery
-
-```typescript
-// Error handling
-const result = await runScript(script);
-if (!result.success) {
-  console.error('Script failed:', result.error);
-  // Implement fallback logic
-}
-```
-
-### Building Records from Variables (Shorthand Methods)
-
-Shorthand methods eliminate boilerplate when extracting properties:
-
-#### setExpression with Record Objects
-
-```typescript
-// OLD WAY - using makeRecordFrom
-const script = createScript()
-  .setExpression('accName', 'name of acc')
-  .setExpression('accId', 'id of acc')
-  .setExpression(
-    'record',
-    createScript().makeRecordFrom({
-      accountName: 'accName',
-      accountId: 'accId',
-    }),
-  );
-
-// NEW WAY - Record objects accepted directly
-const script = createScript()
-  .setExpression('accName', 'name of acc')
-  .setExpression('accId', 'id of acc')
-  .setExpression('record', {
-    accountName: 'accName',
-    accountId: 'accId',
-  });
-```
-
-#### setEndRecord for Ultra-Clean Syntax
-
-`setEndRecord()` combines property extraction and record creation in one step:
-
-```typescript
-// Form 1: Direct expressions (use full expressions)
-const script = createScript()
-  .set('accountInfo', [])
-  .repeatWith('acc', 'every account')
-  .setEndRecord('accountInfo', {
-    accountName: 'name of acc',
-    accountId: 'id of acc',
-    noteCount: 'count of notes in acc',
-  })
-  .end();
-
-// Form 2: Source object shorthand (automatically appends "of source")
-const script = createScript()
-  .set('accountInfo', [])
-  .repeatWith('acc', 'every account')
-  .setEndRecord('accountInfo', 'acc', {
-    accountName: 'name',
-    accountId: 'id',
-    noteCount: 'count of notes',
-  })
-  .end();
-```
-
-**Implementation Details:**
-
-- `setEndRecord()` reduces boilerplate by ~31% vs manual variables
-- Form 1 accepts Record with full expressions
-- Form 2 accepts source object name, constructs "property of source"
-- Both forms generate records and append to lists
-- Type-safe with TypeScript support
-- Validates propertyMap when using source object form
-
-### Explicit Paired Endings
-
-Explicit block endings improve clarity with nested blocks:
-
-```typescript
-// Explicit endings
-const script = createScript()
-  .tell('Finder')
-  .if('count of windows > 0')
-  .raw('activate front window')
-  .endif() // Explicit: ends the if block
-  .endtell() // Explicit: ends the tell block
-  .build();
-
-// Validates block types - errors if mismatched
-builder.if('x > 5').endif(); // ✓ Correct
-builder.repeat(5).endrepeat(); // ✓ Correct
-builder.try().endtry(); // ✓ Correct
-builder.tell('App').endtell(); // ✓ Correct
-
-// Type-safe - throws error if mismatched
-builder.if('x > 5').endrepeat(); // ✗ Error: trying to close repeat, not if
-```
-
-**Available explicit endings:**
-
-- `endif()` - for if blocks
-- `endrepeat()` - for repeat blocks
-- `endtry()` - for try blocks
-- `endtell()` - for tell blocks
-- `endon()` - for on handler blocks
-- `endconsidering()` - for considering blocks
-- `endignoring()` - for ignoring blocks
-- `endusing()` - for using blocks
-- `endwith()` - for with blocks
-
-**Benefits:**
-
-- Eliminates confusion about which `end()` closes which block
-- IDE autocomplete shows all ending options
-- Runtime validation catches mismatched block types
-- Self-documenting code
-
-### Convenience Helper Methods
-
-Convenience helpers simplify patterns and manage block closing:
-
-#### ifThen and ifThenElse
-
-```typescript
-// OLD WAY: Manual
-const script = createScript().if('counter > 10').then().raw('log "greater"').endif();
-
-// NEW WAY: Helper
-const script = createScript().ifThen('counter > 10', (b) => {
-  b.raw('log "greater"');
-});
-
-// if-then-else pattern
-const script = createScript().ifThenElse(
-  'counter > 10',
-  (then_) => {
-    then_.raw('log "greater"');
-  },
-  (else_) => {
-    else_.raw('log "not greater"');
-  },
-);
-```
-
-#### tryCatch
-
-```typescript
-// OLD WAY: Manual try-catch
-const script = createScript().try().raw('activate').onError().raw('log "failed"').endtry();
-
-// NEW WAY: Helper
-const script = createScript().tryCatch(
-  (try_) => {
-    try_.raw('activate');
-  },
-  (catch_) => {
-    catch_.raw('log "failed"');
-  },
-);
-
-// With error variable capture
-const script = createScript().tryCatchError(
-  (try_) => {
-    try_.raw('activate');
-  },
-  'errorMsg', // Error variable name
-  (catch_) => {
-    catch_.raw('log errorMsg');
-  },
-);
-```
-
-**Benefits:**
-
-- Blocks automatically closed - no forgotten `endif()`
-- Callback parameters clearly show scope
-- JavaScript indentation matches block hierarchy
-- Callbacks can use TypeScript features
-
-### Conditional Assignment with setIfExists
-
-The `setIfExists()` and `setEndIfExists()` methods handle optional properties with type conversion and defaults.
-
-```typescript
-// Check if property exists, convert type, or default
-const script = createScript()
-  .tell('Contacts')
-  .repeatWith('aPerson', 'every person')
-  // Check if birth date exists, convert to string, or default
-  .setIfExists(
-    'personBirthday',
-    (e) => e.property('aPerson', 'birth date'),
-    'missing value',
-    'string',
-  )
-  .endrepeat()
-  .endtell();
-```
-
-**Comparison:**
-
-```typescript
-// OLD WAY: setTernary
-.setTernary(
-  'personBirthday',
-  (e) => e.exists(e.property('aPerson', 'birth date')),
-  (e) => e.asType(e.property('aPerson', 'birth date'), 'string'),
-  'missing value',
-)
-
-// NEW WAY: setIfExists
-.setIfExists(
-  'personBirthday',
-  (e) => e.property('aPerson', 'birth date'),
-  'missing value',
-  'string',
-)
-```
-
-**Implementation Details:**
-
-- Generates if-then-else blocks (AppleScript doesn't support inline conditionals)
-- Built-in type conversion via `asType`
-- Default value optional (defaults to `'missing value'`)
-- Both string-based and ExprBuilder expressions supported
-- Type-safe with TypeScript support
-
-**Usage Patterns:**
-
-```typescript
-// Basic existence check
-.setIfExists('personEmail', (e) => e.property('aPerson', 'email'), 'missing value')
-
-// Type conversion
-.setIfExists('createdDate', (e) => e.property('note', 'creation date'), 'missing value', 'string')
-
-// String property
-.setIfExists('personPhone', 'phone of aPerson', '""')
-
-// Append to list
-.setEndIfExists('datesList', (e) => e.property('note', 'creation date'), 'missing value', 'string')
-```
-
-**Generated AppleScript:**
-
-```applescript
-if exists birth date of aPerson then
-  set personBirthday to birth date of aPerson as string
-else
-  set personBirthday to missing value
-end if
-```
-
-**Benefits:**
-
-- More semantic than `setTernary` - shows intent
-- Cleaner API - no manual existence check
-- Self-documenting
-- Consistent default value handling
-- Built-in type conversion
-- Integrates with other builder methods
-
-### Enhanced mapToJson() with PropertyExtractor
-
-The `mapToJson()` method supports field-level transformations using `PropertyExtractor` objects. This eliminates manual extraction loops and simplifies mapping code.
-
-**PropertyExtractor:**
+`mapToJson(iterVar, collection, fieldMap, options)` supports `PropertyExtractor` objects per field:
 
 ```typescript
 interface PropertyExtractor {
   property: string | ((e: ExprBuilder) => string);
   firstOf?: boolean; // Get first item or default
-  ifExists?: boolean; // Check if property exists
-  asType?: string; // Convert to type
-  default?: string | ((e: ExprBuilder) => string); // Default value
+  ifExists?: boolean; // Check existence before access
+  asType?: string; // Type conversion
+  default?: string | ((e: ExprBuilder) => string);
 }
 ```
 
-**Basic Usage:**
+Simple strings for direct properties, `PropertyExtractor` for transformations. Uses `setFirstOf()`/`setIfExists()` internally. See `examples/contacts-automation.ts`.
 
-```typescript
-// Simple string properties
-const script = createScript()
-  .tell('Notes')
-  .mapToJson(
-    'aNote',
-    'every note',
-    {
-      id: 'id',
-      name: 'name',
-      content: 'plaintext',
-    },
-    { limit: 10, skipErrors: true },
-  )
-  .endtell();
-```
+### ExprBuilder
 
-**Advanced Usage - PropertyExtractor:**
-
-```typescript
-// Extract contacts
-const script = createScript()
-  .tell('Contacts')
-  .mapToJson(
-    'aPerson',
-    'every person',
-    {
-      // Simple properties
-      id: 'id',
-      name: 'name',
-      firstName: 'first name',
-      lastName: 'last name',
-      organization: 'organization',
-
-      // Get first email
-      email: {
-        property: (e) => e.property('aPerson', 'emails'),
-        firstOf: true,
-        default: 'missing value',
-      },
-
-      // String property
-      phone: {
-        property: 'phones',
-        firstOf: true,
-      },
-
-      // Optional field with type conversion
-      birthday: {
-        property: 'birth date',
-        ifExists: true,
-        asType: 'string',
-        default: 'missing value',
-      },
-
-      isCompany: 'company',
-    },
-    { limit: 50, skipErrors: true },
-  )
-  .endtell();
-```
-
-**How It Works Internally:**
-
-For each PropertyExtractor field, mapToJson():
-
-1. Generates temporary variable
-2. Calls `setFirstOf()` if `firstOf: true`
-3. Calls `setIfExists()` if `ifExists: true`
-4. Stores transformed value
-5. Uses temp variable in record construction
-
-**Comparison:**
-
-```typescript
-// BEFORE: Manual extraction (~40 lines)
-const oldScript = createScript()
-  .tell('Contacts')
-  .set('contactsList', [])
-  .set('counter', 0)
-  .forEachUntil(
-    'aPerson',
-    'every person',
-    (e) => e.gt('counter', 50),
-    (b) =>
-      b.increment('counter').tryCatch(
-        (tryBlock) =>
-          tryBlock
-            // Manual firstOf for email
-            .setFirstOf('personEmail', (e) => e.property('aPerson', 'emails'), 'missing value')
-            // Manual firstOf for phone
-            .setFirstOf('personPhone', (e) => e.property('aPerson', 'phones'), 'missing value')
-            // Manual ifExists
-            .setIfExists(
-              'personBirthday',
-              (e) => e.property('aPerson', 'birth date'),
-              'missing value',
-              'string',
-            )
-            // Build record
-            .setEndRecord('contactsList', {
-              id: 'id of aPerson',
-              name: 'name of aPerson',
-              firstName: 'first name of aPerson',
-              lastName: 'last name of aPerson',
-              organization: 'organization of aPerson',
-              email: 'personEmail',
-              phone: 'personPhone',
-              birthday: 'personBirthday',
-              isCompany: 'company of aPerson',
-            }),
-        (catchBlock) => catchBlock.comment('Skip contacts with errors'),
-      ),
-  )
-  .returnAsJson('contactsList', {
-    id: 'id',
-    name: 'name',
-    firstName: 'firstName',
-    lastName: 'lastName',
-    organization: 'organization',
-    email: 'email',
-    phone: 'phone',
-    birthday: 'birthday',
-    isCompany: 'isCompany',
-  })
-  .endtell();
-
-// AFTER: PropertyExtractor (~15 lines)
-const newScript = createScript()
-  .tell('Contacts')
-  .mapToJson(
-    'aPerson',
-    'every person',
-    {
-      id: 'id',
-      name: 'name',
-      firstName: 'first name',
-      lastName: 'last name',
-      organization: 'organization',
-      email: { property: (e) => e.property('aPerson', 'emails'), firstOf: true },
-      phone: { property: 'phones', firstOf: true },
-      birthday: { property: 'birth date', ifExists: true, asType: 'string' },
-      isCompany: 'company',
-    },
-    { limit: 50, skipErrors: true },
-  )
-  .endtell();
-```
-
-**PropertyExtractor Options:**
-
-- **firstOf**: Checks if collection has items, gets `value of item 1`, or uses default
-  - Generates: `if count of <property> > 0 then ... else ...`
-  - Perfect for multi-value fields
-- **ifExists**: Checks if property exists before accessing
-  - Generates: `if exists <property> then ... else ...`
-  - Optional type conversion via `asType`
-  - Perfect for optional fields
-- **asType**: Converts to specified AppleScript type
-  - Example: `asType: 'string'` generates `as string`
-  - Works with both firstOf and ifExists
-- **default**: Default value if property missing or collection empty
-  - Can be string literal or ExprBuilder callback
-  - Defaults to `'missing value'` if not specified
-
-**Generated AppleScript Example:**
-
-For the contacts example, mapToJson() generates approximately:
-
-```applescript
-tell application "Contacts"
-  set __collected_items to {}
-  set __counter to 0
-  repeat with aPerson in every person
-    if __counter >= 50 then
-      exit repeat
-    end if
-    set __counter to __counter + 1
-
-    -- firstOf for email
-    if count of emails of aPerson > 0 then
-      set __temp_email to value of item 1 of emails of aPerson
-    else
-      set __temp_email to missing value
-    end if
-
-    -- firstOf for phone
-    if count of phones > 0 then
-      set __temp_phone to value of item 1 of phones
-    else
-      set __temp_phone to missing value
-    end if
-
-    -- ifExists for birthday
-    if exists birth date then
-      set __temp_birthday to birth date as string
-    else
-      set __temp_birthday to missing value
-    end if
-
-    try
-      set end of __collected_items to {
-        id:id of aPerson,
-        name:name of aPerson,
-        firstName:first name of aPerson,
-        lastName:last name of aPerson,
-        organization:organization of aPerson,
-        email:__temp_email of aPerson,
-        phone:__temp_phone of aPerson,
-        birthday:__temp_birthday of aPerson,
-        isCompany:company of aPerson
-      }
-    on error
-      -- Skip items with errors
-    end try
-  end repeat
-
-  -- JSON conversion code...
-  return jsonArray
-end tell
-```
-
-**Key Benefits:**
-
-- **62.5% code reduction**: From ~40 to ~15 lines
-- **Declarative syntax**: Describes what you want
-- **Type-safe**: TypeScript support
-- **Backward compatible**: Simple string properties work
-- **Self-documenting**: Transformations inline
-- **Leverages existing methods**: Uses `setFirstOf()` and `setIfExists()` internally
-- **Consistent behavior**: Same transformation logic
-- **Reduces bugs**: Less manual code
-
-**Real-World Example - See `examples/contacts-automation.ts`:**
-
-The contacts example demonstrates extracting contact data with required fields, multi-value fields, and optional fields. PropertyExtractor reduces code from ~40 to ~15 lines while maintaining clarity and type safety.
-
-### Type-Safe Expressions with ExprBuilder
-
-`ExprBuilder` provides type-safe expression building:
-
-```typescript
-import { ExprBuilder } from 'applescript-node';
-
-// OLD WAY: String-based conditions
-.if('counter > 10')  // Typo: no error until runtime!
-
-// NEW WAY: Type-safe
-.if((e) => e.gt('counter', 10))  // ✓ Autocomplete, type checking
-
-// Comparison operators
-const e = new ExprBuilder();
-e.gt('x', 5)              // x > 5
-e.lt('x', 5)              // x < 5
-e.gte('x', 5)             // x ≥ 5
-e.lte('x', 5)             // x ≤ 5
-e.eq('status', 'done')    // status = "done"
-e.ne('status', 'pending') // status ≠ "pending"
-
-// String operations
-e.length('name')          // length of name
-e.contains('name', '"J"') // name contains "J"
-e.startsWith('text', '"A"') // text begins with "A"
-e.endsWith('text', '"Z"') // text ends with "Z"
-
-// Property and count operations
-e.property('note', 'name')      // name of note
-e.count('notes')                // count of notes
-e.exists('window "Settings"')   // exists window "Settings"
-e.typeEquals('value', 'text')   // the type of value is text
-
-// Logical operators
-e.and('x > 5', 'y < 10')        // x > 5 and y < 10
-e.or('x > 5', 'y > 10')         // x > 5 or y > 10
-e.not('exists window')          // not exists window
-
-// Complex expressions
-const cond = e.and(
-  e.gt(e.length('name'), 5),
-  e.eq('status', 'active')
-);
-// Produces: length of name > 5 and status = "active"
-```
-
-**Usage with builder:**
-
-```typescript
-const script = createScript()
-  .tell('Notes')
-  .set('notesList', [])
-  .repeatWith('aNote', 'every note')
-  // Use ExprBuilder for condition
-  .ifThen(
-    (e) => e.gt('counter', 50),
-    (b) => {
-      b.exitRepeat();
-    },
-  )
-  .tryCatch(
-    (b) => {
-      b.setExpression('notePlaintext', 'plaintext of aNote');
-      // Nested expressions
-      b.ifThenElse(
-        (e) => e.gt(e.length('notePlaintext'), 100),
-        (then_) => {
-          then_.setExpression('notePreview', 'text 1 thru 100 of notePlaintext & "..."');
-        },
-        (else_) => {
-          else_.set('notePreview', 'notePlaintext');
-        },
-      );
-      b.setEndRecord('notesList', {
-        noteName: 'name of aNote',
-        noteId: 'id of aNote',
-        preview: 'notePreview',
-      });
-    },
-    (c) => {
-      c.comment('Skip notes with errors');
-    },
-  )
-  .endrepeat()
-  .returnRaw('notesList')
-  .endtell()
-  .build();
-```
-
-**Benefits:**
-
-- Type-safe conditions with TypeScript checking
-- IDE autocomplete
-- Self-documenting: `e.gt()` is clearer than `>`
-- Composable expressions with `and()`, `or()`, `not()`
-- Prevents property name typos
+Type-safe expressions: `e.gt()`, `e.lt()`, `e.eq()`, `e.ne()`, `e.gte()`, `e.lte()`, `e.and()`, `e.or()`, `e.not()`, `e.length()`, `e.contains()`, `e.startsWith()`, `e.endsWith()`, `e.property()`, `e.count()`, `e.exists()`. Composable, IDE-autocomplete-friendly.
 
 ## Development Guidelines
 
-### Adding New Features
+1. Type definitions in `types.ts` first
+2. Tests required for new functionality
+3. Maintain 80%+ coverage
+4. Backward compatibility for existing APIs
 
-When extending:
+**Import alias**: `applescript-node` maps to `./src/index.ts` for internal imports.
 
-1. **Type definitions first**: Add types to `types.ts` before implementation
-2. **Builder methods**: Add methods to `AppleScriptBuilder` class
-3. **Tests required**: Unit tests for new functionality
-4. **Documentation**: Update README and examples
-5. **Backward compatibility**: Ensure existing APIs remain stable
+## Security
 
-### Testing New Code
+**String escaping order**: Escape backslashes FIRST, THEN quotes. See `setClipboard()` in `sources/system.ts`.
 
-Testing requirements:
+**DON'T** use multi-line `${...}` in README code examples — CI `gh pr diff` bash parser expands them. Extract to single-line variable first.
 
-- **Unit tests**: Test methods and classes
-- **Integration tests**: Test with real `osascript`
-- **Error cases**: Test failure scenarios
-- **Type safety**: Ensure TypeScript types correct
-- **Coverage**: Maintain 80%+
+## Troubleshooting
 
-### Code Review Checklist
-
-Before submitting changes:
-
-- [ ] All tests pass (`pnpm test`)
-- [ ] Type checking passes (`pnpm typecheck`)
-- [ ] Linting passes (`pnpm lint`)
-- [ ] Code is formatted (`pnpm format`)
-- [ ] New features have tests
-- [ ] Documentation is updated
-- [ ] Examples work correctly
-
-## Testing Considerations
-
-### Platform Requirements
-
-- **macOS only**: Tests require `osascript`
-- **Real execution**: Integration tests use actual `osascript`
-- **Mocking strategy**: Unit tests mock `child_process.exec`
-- **Error simulation**: Test success and failure scenarios
-
-### Test Categories
-
-- **Unit tests**: Method and class testing with mocks
-- **Integration tests**: Full workflow testing with real `osascript`
-- **Error handling**: Test script failures, syntax errors, system errors
-- **Type safety**: Validate TypeScript type checking
-- **Block validation**: Test builder block stack validation
-
-### Mocking Patterns
-
-```typescript
-// Mock successful execution
-vi.mocked(exec).mockResolvedValueOnce({
-  stdout: 'expected output',
-  stderr: '',
-});
-
-// Mock execution failure
-vi.mocked(exec).mockRejectedValueOnce(new Error('Script execution failed'));
-```
-
-## Import Path Aliasing
-
-Path aliasing for development:
-
-- **`applescript-node`** maps to `./src/index.ts` for internal imports
-- **External package simulation**: Internal imports mimic external package usage
-- **TypeScript resolution**: Module resolution
-- **IDE support**: IntelliSense and navigation
-
-## File Structure and Organization
-
-### Source Code Layout
-
-```
-src/
-├── index.ts          # Main entry point and public API
-├── types.ts          # Central type definitions
-├── executor.ts       # Script execution engine
-├── builder.ts        # Fluent builder implementation
-├── compiler.ts       # Script compilation
-├── decompiler.ts     # Script decompilation
-└── languages.ts      # Language discovery and capabilities
-```
-
-### Example Code Organization
-
-```
-examples/
-├── basic-script.ts      # Simple script execution
-├── fluent-builder.ts    # Builder API demonstration
-├── script-compilation.ts # Compilation examples
-├── script-decompilation.ts # Decompilation examples
-├── language-info.ts     # Language discovery
-├── list-applications.ts # Application management
-├── window-management.ts # Window control
-└── output/             # Generated script files
-```
-
-### Test Organization
-
-```
-src/
-├── executor.test.ts     # Execution engine tests
-├── builder.test.ts      # Builder functionality tests
-├── compiler.test.ts     # Compilation tests
-├── decompiler.test.ts   # Decompilation tests
-└── languages.test.ts    # Language discovery tests
-```
-
-## Performance and Optimization
-
-### Execution Performance
-
-- **Direct process spawning**: Uses `child_process.exec`
-- **Minimal overhead**: Lightweight wrapper
-- **Memory efficiency**: Lazy building
-- **Concurrent execution**: Supports parallel execution
-
-### Build Performance
-
-- **Incremental builds**: tsup supports incremental compilation
-- **Type-only builds**: Separate TypeScript compilation
-- **Parallel processing**: Multiple build steps
-- **Caching**: Language information and capabilities cached
-
-### Development Experience
-
-- **Fast feedback**: Watch mode
-- **Type checking**: Real-time TypeScript errors
-- **Hot reloading**: Automatic rebuild
-- **Comprehensive tooling**: IDE support
-
-## Security Considerations
-
-### Script Execution Safety
-
-- **Input validation**: Escaping script strings
-- **Error isolation**: Script failures don't crash process
-- **Permission handling**: Respects macOS permissions
-- **Sandboxing**: Scripts run in isolated processes
-
-**String escaping order matters**: When escaping user input for AppleScript strings:
-
-1. Escape backslashes FIRST: `text.replace(/\\/g, '\\\\')`
-2. THEN escape quotes: `.replace(/"/g, '\\"')`
-
-**DON'T** escape quotes before backslashes - this corrupts already-escaped backslashes. See `setClipboard()` in `sources/system.ts` for the correct pattern.
-
-**DON'T** use multi-line TypeScript template literals with `${...}` spanning multiple lines in README code examples. The `claude-code-review` CI workflow runs `gh pr diff` and the bash parser tries to expand `${variableName}` as a shell variable, failing with `Bad substitution: variableName`. This affects any `${expr\n.method()}` pattern where the closing `}` is on a different line than the opening `${`.
-
-**Fix**: Extract the complex expression into a named variable on its own line so that the `${...}` fits on a single line:
-
-```typescript
-// DON'T: multi-line template literal causes CI "Bad substitution" error
-.raw(`set body to "${items
-  .map((t) => `${t.title}`)
-  .join('\\n')}"`)
-
-// DO: extract to variable first
-const itemLines = items.map((t) => `${t.title}`).join('\\n');
-.raw(`set body to "${itemLines}"`)
-```
-
-### Code Quality Security
-
-- **Type safety**: Prevents runtime errors
-- **Static analysis**: ESLint catches security issues
-- **Dependency management**: Regular updates
-- **Audit tools**: Vulnerability scanning
-
-## Troubleshooting Common Issues
-
-### Build Issues
-
-- **TypeScript errors**: Run `pnpm typecheck` to identify issues
+- **Missing .d.ts in dist/**: Delete `tsconfig.build.tsbuildinfo` and rebuild
+- **IDE "Cannot find name 'Promise'"**: Language server noise. Run `pnpm typecheck` to verify — if it passes, ignore
 - **Import errors**: Ensure `.js` extensions
-- **Module resolution**: Check tsconfig.json mappings
-- **Missing type definitions in dist/**: Delete `tsconfig.build.tsbuildinfo` and rebuild. The `build:types` script should already handle this, but if types are missing after build, this is the cause.
 
-### Runtime Issues
+## npm Release Workflow
 
-- **Script execution failures**: Check `osascript` availability
-- **Block validation errors**: Ensure `end()` calls
-- **Type errors**: Verify generic type parameters
+**Pre-release**: Clean git, `pnpm test`, `pnpm lint`, `pnpm audit`, `pnpm build`, verify .d.ts in dist/.
 
-### Development Issues
+**Version bump**: `unset npm_config_prefix && pnpm version patch|minor|major` (use `pnpm version` not `npm version`). Creates commit + tag. Requires clean git state.
 
-- **Test failures**: Ensure tests run on macOS with `osascript`
-- **Linting errors**: Run `pnpm format:fix` to auto-fix
-- **Coverage failures**: Add tests for uncovered paths
-- **IDE diagnostics showing "Cannot find name 'Promise'" or similar**: These are TypeScript language server noise (false positives about built-in types). Run `pnpm typecheck` to verify actual type errors - if it passes, ignore the IDE diagnostics
-
-## Contributing Workflow
-
-### Getting Started
-
-1. Fork and clone
-2. Install dependencies
-3. Run tests
-4. Create feature branch
-
-### Development Process
-
-1. Make changes following standards
-2. Add tests
-3. Run quality checks
-4. Update documentation
-5. Submit pull request
-
-### Release Process
-
-1. Version bump
-2. Update changelog
-3. Run verification
-4. Publish to npm
-5. Create GitHub release
-
-### npm Release Workflow
-
-**Pre-release checklist:**
-
-1. Ensure working directory is clean (`git status`)
-2. Run `pnpm test` and `pnpm lint` - fix all errors before proceeding
-3. Run `pnpm audit` - fix high/critical vulnerabilities in production dependencies before publishing
-4. Run `pnpm build` and verify dist/ contains .d.ts type definition files
-
-**Version bump requires clean git state:**
-
-- `pnpm version patch|minor|major` fails if there are uncommitted changes
-- Commit all lint fixes, dependency updates, and config changes before bumping version
-- The version bump creates both a commit and a git tag automatically
-- **`npm_config_prefix` conflicts with nvm inside husky hooks** — `pnpm version patch`
-  will fail with "husky - pre-commit script failed (code 11)" if `npm_config_prefix` is
-  set. Fix: `unset npm_config_prefix && pnpm version patch`. If the version bump commits
-  but tag creation fails, create the tag manually with `git tag v<version>`.
-- Use `pnpm version` not `npm version` — the pnpm-swizzle hook blocks bare `npm` commands.
-
-**Publishing with 2FA:**
+**Publish**:
 
 ```bash
-# Get OTP from 1Password (item name is "Npmjs", not "npmjs.com")
-op item get "Npmjs" --otp
-
-# Publish atomically — fetch OTP and publish in one step to avoid TOTP expiry
 OTP=$(op item get "Npmjs" --otp) && unset npm_config_prefix && pnpm publish --otp=$OTP
 ```
 
-If `pnpm whoami` shows "not logged in" and publish returns 404/401, the token has
-expired. Re-authenticate via the registry REST API:
+From non-main branches add `--no-git-checks`. Always `pnpm publish --dry-run` first.
+
+**Re-auth** if token expired:
 
 ```bash
 PASSWORD=$(op item get "Npmjs" --fields password --reveal)
@@ -1180,148 +154,21 @@ sed -i '' '/registry.npmjs.org\/:_authToken/d' ~/.npmrc
 echo "//registry.npmjs.org/:_authToken=$TOKEN" >> ~/.npmrc
 ```
 
-**Branch protection handling:**
+**Branch protection**: Direct push to main blocked. Create release branch + PR, use `gh pr merge --squash --auto`. Tags can be pushed directly.
 
-- Direct push to main is blocked by repository rules requiring PRs and CI checks
-- After publishing to npm, create a release branch and PR:
-  ```bash
-  git checkout -b release/v<version>
-  git push origin release/v<version>
-  gh pr create --title "Release v<version>" --body "..." --base main
-  gh pr merge <PR_NUMBER> --squash --auto
-  ```
-- The tag can be pushed directly even when main is protected
-- When publishing from a non-main branch (e.g., `release/v<version>` or `fix/`), pass
-  `--no-git-checks` to suppress pnpm's interactive branch prompt:
-  `pnpm publish --otp=$OTP --no-git-checks`
-
-**Dry run inspection:**
-
-- Always run `pnpm publish --dry-run` before actual publish
-- Verify the tarball contains type definitions (.d.ts files)
-- Verify no private files (.env, credentials) are included
-- Check the `files` field in package.json restricts to `dist/` only
-
-**`exports` field is required for ESM consumers:**
-
-The package must have a conditional `exports` field or named ESM imports will fail with
-"does not provide an export named 'X'". The correct structure — note `types` must come
-**first** (before `import`/`require`) for TypeScript resolution:
+**Exports field required** — `types` must come first:
 
 ```json
-"exports": {
-  ".": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
-  }
-}
+"exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.mjs", "require": "./dist/index.js" } }
 ```
 
-Without this field, Node.js ESM falls back to `"main"` → `dist/index.js`. With
-`"type": "module"` in the package, `dist/index.js` is treated as ESM format but contains
-CJS syntax (`exports.X = Y`), causing the named-export resolution to fail.
+**Smoke tests**: Use isolated temp dir with `.npmrc` sentinel to prevent workspace contamination.
 
-**Post-release smoke tests:**
+**API shape**: `result.output`, `result.success`, `result.exitCode`. Language discovery: `getInstalledLanguages()`.
 
-Run smoke tests in a fully isolated temp directory. A missing `.npmrc` file in the temp
-dir causes pnpm to treat it as part of the workspace, contaminating the root
-`pnpm-lock.yaml` with the package as its own dependency:
+## CI/CD Rules
 
-```bash
-SMOKE=$(mktemp -d)
-printf "# isolated\n" > "$SMOKE/.npmrc"   # prevent workspace adoption
-printf '{"name":"smoke-test","version":"1.0.0","type":"module"}\n' > "$SMOKE/package.json"
-pnpm --prefix "$SMOKE" add applescript-node@latest
-```
-
-The `runScript()` result shape uses `output` (not `result`): `result.output`, `result.success`,
-`result.exitCode`. Language discovery is `getInstalledLanguages()` (not `getLanguages()`).
-
-## CI/CD and PR Merge Guidelines
-
-### CRITICAL: Never Bypass CI
-
-**Branch protection and CI checks exist for good reasons. Never attempt to circumvent them.**
-
-#### Absolute Rules
-
-1. **NEVER use `--admin` flag** to bypass branch protection or required status checks
-2. **NEVER attempt to force-merge** when CI is still running
-3. **CI running is the NORMAL state** - it is supposed to run and complete before merging
-4. **Be patient** - wait for all checks to pass naturally
-
-#### Correct PR Merge Workflow
-
-```bash
-# 1. Set up auto-merge (correct approach)
-gh pr merge <PR_NUMBER> --squash --auto
-
-# 2. Monitor checks if needed
-gh pr checks <PR_NUMBER>
-
-# 3. Wait for checks to complete - DO NOT try to force it
-# The --auto flag will merge automatically when all checks pass
-
-# 4. Verify merge completed
-gh pr view <PR_NUMBER> --json state
-```
-
-#### What NOT To Do
-
-```bash
-# WRONG: Trying to merge while checks are pending
-gh pr merge <PR_NUMBER> --squash  # Will fail - this is expected!
-
-# WRONG: Bypassing with admin privileges
-gh pr merge <PR_NUMBER> --squash --admin  # NEVER DO THIS
-
-# WRONG: Being impatient when auto-merge is already set
-# Just wait - the merge will happen automatically when checks pass
-```
-
-#### Why This Matters
-
-- **CI protects code quality**: Required checks catch bugs before they reach main
-- **Branch protection is intentional**: It exists to enforce review and quality standards
-- **Bypassing undermines trust**: The team relies on CI to validate changes
-- **"Completing tasks quickly" is not an excuse**: Quality > speed
-
-#### When Checks Are Pending
-
-If `gh pr merge --squash --auto` is set and checks are pending:
-
-1. **Wait** - this is normal
-2. **Monitor** with `gh pr checks <PR_NUMBER>` if needed
-3. **Do not escalate** to `--admin` or other bypass methods
-4. **If checks fail**, investigate and fix the issue - don't bypass
-
-#### When CI Doesn't Trigger After a Push
-
-If `gh run list --branch <branch>` shows only old runs after pushing to a PR branch, the branch likely has merge conflicts. GitHub silently skips firing `pull_request: synchronize` workflow events for PRs in `mergeable_state: dirty`.
-
-**Diagnose:**
-
-```bash
-REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-gh api "repos/$REPO/pulls/<PR_NUMBER>" --jq '{mergeable, mergeable_state}'
-```
-
-**Fix:** Rebase onto `main`, then force-push:
-
-```bash
-git fetch origin main && git rebase origin/main
-git push --force-with-lease origin <branch>
-```
-
-Confirm CI picked up the new commit by checking the commit's check-runs:
-
-```bash
-gh api "repos/$REPO/commits/<sha>/check-runs" --jq '.check_runs[].name'
-```
-
-An empty result means CI has not yet registered the commit. A non-empty result confirms workflows are running.
-
-#### Summary
-
-The correct mental model: CI checks are gatekeepers, not obstacles. When they're running, the system is working as designed. Patience and respect for the process is required.
+- **NEVER** use `--admin` to bypass branch protection
+- **NEVER** force-merge while CI runs
+- Use `gh pr merge --squash --auto` and wait
+- If CI doesn't trigger after push, check for merge conflicts: `gh api "repos/$REPO/pulls/<PR>" --jq '{mergeable, mergeable_state}'`. Fix: rebase onto main, force-push with lease.


### PR DESCRIPTION
## Summary
- Compact CLAUDE.md from 5390 words / 1327 lines to ~950 words / 174 lines
- Preserves all technical specifics, commands, and DO/DON'T directives
- Removes verbose code examples, redundant sections, and filler

## Test plan
- [x] No code changes — documentation only
- [x] All tests pass (810/810)
- [x] Lint and typecheck clean