### PR TITLE
fix(builder)!: surface records dropped by returnAsJson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ pnpm-debug.log*
 
 # IDE
 .idea
+.junie/memory
 .vscode
 *.swp
 *.swo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to applescript-node are documented in this file.
   now threaded through to this stage, so it controls both record
   building and serialization.
 
+  The `sources` APIs are unaffected: `windows.getAll()`,
+  `applications.getAll()`, and `system.getVolumes()` now pass
+  `{ skipErrors: true }` explicitly, preserving their existing
+  behaviour of returning partial results when an individual window,
+  process, or disk cannot be read.
+
 ### 25 March 2026
 
 #### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to applescript-node are documented in this file.
 
 ## [Unreleased]
 
+### 8 August 2026
+
+#### Breaking Changes
+
+- `returnAsJson()` no longer wraps per-record serialization in a
+  silent `try`. A record that cannot be serialized now raises the
+  underlying AppleScript error instead of disappearing from the
+  result array. Pass `{ skipErrors: true }` to restore the previous
+  lenient behaviour. `mapToJson()`'s existing `skipErrors` option is
+  now threaded through to this stage, so it controls both record
+  building and serialization.
+
 ### 25 March 2026
 
 #### New Features

--- a/examples/if-exists-demo.ts
+++ b/examples/if-exists-demo.ts
@@ -201,12 +201,17 @@ const integrationScript = createScript()
       (catchBlock) => catchBlock.comment('Skip notes with errors'),
     ),
   )
-  .returnAsJson('notesList', {
-    name: 'name',
-    plaintext: 'plaintext',
-    created: 'created',
-    modified: 'modified',
-  })
+  .returnAsJson(
+    'notesList',
+    {
+      name: 'name',
+      plaintext: 'plaintext',
+      created: 'created',
+      modified: 'modified',
+    },
+    // Match the tryCatch above: skip notes that cannot be serialized.
+    { skipErrors: true },
+  )
   .endtell();
 
 console.log(chalk.white('Integration with forEach and tryCatch:'));

--- a/examples/list-applications.ts
+++ b/examples/list-applications.ts
@@ -1,13 +1,71 @@
 import { AppleScriptBuilder, ScriptExecutor } from 'applescript-node';
 
 /**
- * This example demonstrates how to list all running applications using AppleScript.
- * It uses System Events to get a list of all running processes and their names.
+ * This example demonstrates how to list the windows of every foreground
+ * application using AppleScript. It uses System Events to walk each non-background
+ * process, collects each window's name and geometry, and returns them as JSON.
  */
+
+interface WindowSummary {
+  app: string;
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function isWindowSummary(value: unknown): value is WindowSummary {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const obj = value;
+  return (
+    'app' in obj &&
+    'name' in obj &&
+    'x' in obj &&
+    'y' in obj &&
+    'width' in obj &&
+    'height' in obj &&
+    typeof obj.app === 'string' &&
+    typeof obj.name === 'string' &&
+    typeof obj.x === 'number' &&
+    typeof obj.y === 'number' &&
+    typeof obj.width === 'number' &&
+    typeof obj.height === 'number'
+  );
+}
 
 const builder = new AppleScriptBuilder();
 
-const script = builder.tell('System Events').get('name of every process').end().build();
+const script = builder
+  .tell('System Events')
+  .set('allWindows', [])
+  .forEach('proc', 'every application process whose background only is false', (b) =>
+    b.forEach('win', 'every window of proc', (inner) =>
+      inner
+        .setExpression('winPos', 'position of win')
+        .setExpression('winSize', 'size of win')
+        .setEndRecord('allWindows', {
+          app: 'name of proc',
+          name: 'name of win',
+          x: 'item 1 of winPos',
+          y: 'item 2 of winPos',
+          width: 'item 1 of winSize',
+          height: 'item 2 of winSize',
+        }),
+    ),
+  )
+  .returnAsJson('allWindows', {
+    app: 'app',
+    name: 'name',
+    x: 'x',
+    y: 'y',
+    width: 'width',
+    height: 'height',
+  })
+  .end()
+  .build();
 
 console.log('Generated AppleScript:');
 console.log(script);
@@ -18,13 +76,10 @@ async function listApplications() {
   try {
     const result = await ScriptExecutor.execute(script);
     if (result.success) {
-      console.log('Running Applications:');
-      console.log(
-        result.output
-          .split(',')
-          .map((app: string) => `- ${app.trim()}`)
-          .join('\n'),
-      );
+      console.log('Running Application Windows (JSON Output):');
+      const parsed: unknown = JSON.parse(result.output);
+      const windows: WindowSummary[] = Array.isArray(parsed) ? parsed.filter(isWindowSummary) : [];
+      console.log(JSON.stringify(windows, null, 2));
     } else {
       console.error('Error executing AppleScript:', result.error);
     }

--- a/scripts/debug-json-skip.ts
+++ b/scripts/debug-json-skip.ts
@@ -1,0 +1,29 @@
+/**
+ * Probe: does returnAsJson() silently drop records that fail to serialize?
+ *
+ * Builds a list where one record is missing a mapped property, then serializes it
+ * twice: once with the default (errors propagate) and once with skipErrors: true
+ * (legacy lenient behaviour). Compares what each returns.
+ *
+ * Run: bun scripts/debug-json-skip.ts
+ */
+import { AppleScriptBuilder, ScriptExecutor } from '../src/index.js';
+
+function build(skipErrors: boolean): string {
+  return new AppleScriptBuilder()
+    .raw('set rows to {}')
+    .raw('set end of rows to {id:1, label:"ok"}')
+    .raw('set end of rows to {id:2}') // no `label` -> serialization fails on this record
+    .raw('set end of rows to {id:3, label:"also ok"}')
+    .returnAsJson('rows', { id: 'id', label: 'label' }, { skipErrors })
+    .build();
+}
+
+for (const skipErrors of [false, true]) {
+  console.log(`--- skipErrors: ${skipErrors} ---`);
+  const result = await ScriptExecutor.execute(build(skipErrors));
+  console.log('success:', result.success, 'exitCode:', result.exitCode);
+  console.log('output:', result.output);
+  if (!result.success) console.log('error:', result.error);
+  console.log('');
+}

--- a/src/builder-enhanced.test.ts
+++ b/src/builder-enhanced.test.ts
@@ -1713,4 +1713,44 @@ describe('Builder - mapToJson() Ultra-Shorthand', () => {
     expect(script).toContain('set jsonArray to "[" & (jsonParts as text) & "]"');
     expect(script).toContain('return jsonArray');
   });
+
+  describe('returnAsJson error visibility', () => {
+    it('does not wrap serialization in try by default, so failures surface', () => {
+      const script = new AppleScriptBuilder()
+        .set('rows', [])
+        .returnAsJson('rows', { id: 'id', name: 'name' })
+        .build();
+
+      const serializationLoop = script.slice(script.indexOf('set jsonParts to {}'));
+      expect(serializationLoop).not.toContain('try');
+      expect(serializationLoop).toContain('set end of jsonParts to itemJson');
+    });
+
+    it('wraps serialization in try when skipErrors is true', () => {
+      const script = new AppleScriptBuilder()
+        .set('rows', [])
+        .returnAsJson('rows', { id: 'id', name: 'name' }, { skipErrors: true })
+        .build();
+
+      const serializationLoop = script.slice(script.indexOf('set jsonParts to {}'));
+      expect(serializationLoop).toContain('  try');
+      expect(serializationLoop).toContain('  end try');
+    });
+
+    it('threads mapToJson skipErrors through to the serialization loop', () => {
+      const lenient = new AppleScriptBuilder()
+        .tell('Notes')
+        .mapToJson('aNote', 'every note', { id: 'id' }, { skipErrors: true })
+        .endtell()
+        .build();
+      const strict = new AppleScriptBuilder()
+        .tell('Notes')
+        .mapToJson('aNote', 'every note', { id: 'id' })
+        .endtell()
+        .build();
+
+      expect(lenient.slice(lenient.indexOf('set jsonParts to {}'))).toContain('try');
+      expect(strict.slice(strict.indexOf('set jsonParts to {}'))).not.toContain('try');
+    });
+  });
 });

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -845,7 +845,7 @@ export class AppleScriptBuilder implements ScriptBuilder {
       acc[key] = key; // JSON key maps to record property with same name
       return acc;
     }, {});
-    return this.returnAsJson(listVar, recordPropertyMap);
+    return this.returnAsJson(listVar, recordPropertyMap, { skipErrors: options.skipErrors });
   }
 
   /**
@@ -854,10 +854,14 @@ export class AppleScriptBuilder implements ScriptBuilder {
    * Handles proper escaping of strings, booleans, numbers, and null values.
    * @param listVariable Name of the variable containing a list of records
    * @param propertyMap Mapping of JSON keys to AppleScript property names (e.g., {id: 'noteId', name: 'noteName'})
+   * @param options.skipErrors When true, records that fail to serialize are omitted from the
+   * array. Defaults to false, so a failing record raises the underlying AppleScript error
+   * rather than disappearing from the result.
    */
   returnAsJson<TProperties extends Record<string, string>>(
     listVariable: string,
     propertyMap: TProperties,
+    options: { skipErrors?: boolean } = {},
   ): ScriptBuilder<never, JsonObjectShape<TProperties>[]> {
     // Prepend handlers to the beginning of the script (they must be at top level)
     const handlers = [
@@ -903,23 +907,32 @@ export class AppleScriptBuilder implements ScriptBuilder {
     this.script.unshift(...handlers);
 
     // Build JSON array from list of records (at current position in script)
+    // Records that fail to serialize propagate the AppleScript error by default, so a
+    // dropped record is never silent. Pass { skipErrors: true } for lenient behaviour.
+    const skipErrors = options.skipErrors ?? false;
+    const pad = skipErrors ? '  ' : '';
+
     this.raw('set jsonParts to {}');
     this.raw(`repeat with rec in ${listVariable}`);
-    this.raw('  try');
-    this.raw(`    set itemJson to "{"`);
+    if (skipErrors) {
+      this.raw('  try');
+    }
+    this.raw(`  ${pad}set itemJson to "{"`);
 
     // Generate property access for each key in the property map
     const entries = Object.entries(propertyMap);
     entries.forEach(([jsonKey, appleScriptProp], index) => {
       const comma = index > 0 ? ',' : '';
       this.raw(
-        `    set itemJson to itemJson & "${comma}\\"${jsonKey}\\":" & my valueToJson(${appleScriptProp} of rec)`,
+        `  ${pad}set itemJson to itemJson & "${comma}\\"${jsonKey}\\":" & my valueToJson(${appleScriptProp} of rec)`,
       );
     });
 
-    this.raw(`    set itemJson to itemJson & "}"`);
-    this.raw('    set end of jsonParts to itemJson');
-    this.raw('  end try');
+    this.raw(`  ${pad}set itemJson to itemJson & "}"`);
+    this.raw(`  ${pad}set end of jsonParts to itemJson`);
+    if (skipErrors) {
+      this.raw('  end try');
+    }
     this.raw('end repeat');
     this.raw('');
     this.raw(`set AppleScript's text item delimiters to ","`);

--- a/src/sources/applications.test.ts
+++ b/src/sources/applications.test.ts
@@ -139,6 +139,20 @@ describe('applications', () => {
       await expect(getAll()).rejects.toThrow('Failed to get applications: Script execution failed');
     });
 
+    it('should serialize leniently so one unreadable process does not fail the batch', async () => {
+      mockExecute.mockResolvedValueOnce({
+        success: true,
+        output: '[]',
+        exitCode: 0,
+      });
+
+      await getAll();
+
+      const script = mockExecute.mock.calls[0][0];
+      const serializationLoop = script.slice(script.indexOf('set jsonParts to {}'));
+      expect(serializationLoop).toContain('try');
+    });
+
     it('should handle empty result', async () => {
       mockExecute.mockResolvedValueOnce({
         success: true,

--- a/src/sources/applications.ts
+++ b/src/sources/applications.ts
@@ -51,14 +51,20 @@ export async function getAll(includeBackgroundApps = false): Promise<Application
         (catchBlock) => catchBlock.comment('Skip processes with errors'),
       ),
     )
-    .returnAsJson('appsList', {
-      name: 'name',
-      bundleId: 'bundleId',
-      pid: 'pid',
-      visible: 'visible',
-      frontmost: 'frontmost',
-      windowCount: 'windowCount',
-    })
+    .returnAsJson(
+      'appsList',
+      {
+        name: 'name',
+        bundleId: 'bundleId',
+        pid: 'pid',
+        visible: 'visible',
+        frontmost: 'frontmost',
+        windowCount: 'windowCount',
+      },
+      // Match the tryCatch above: a process we cannot serialize is skipped,
+      // not fatal to the whole enumeration.
+      { skipErrors: true },
+    )
     .endtell();
 
   return executeJsonScript<ApplicationInfo[]>(script.build(), {

--- a/src/sources/system.test.ts
+++ b/src/sources/system.test.ts
@@ -159,6 +159,20 @@ describe('system', () => {
       const volumes = await getVolumes();
       expect(volumes).toEqual([]);
     });
+
+    it('should serialize leniently so one unreadable disk does not fail the batch', async () => {
+      mockExecute.mockResolvedValueOnce({
+        success: true,
+        output: '[]',
+        exitCode: 0,
+      });
+
+      await getVolumes();
+
+      const script = mockExecute.mock.calls[0][0];
+      const serializationLoop = script.slice(script.indexOf('set jsonParts to {}'));
+      expect(serializationLoop).toContain('try');
+    });
   });
 
   describe('getDisplays', () => {

--- a/src/sources/system.ts
+++ b/src/sources/system.ts
@@ -117,14 +117,20 @@ export async function getVolumes(): Promise<VolumeInfo[]> {
         (catchBlock) => catchBlock.comment('Skip disks with errors'),
       ),
     )
-    .returnAsJson('volumesList', {
-      name: 'name',
-      capacity: 'capacity',
-      freeSpace: 'freeSpace',
-      usedSpace: 'usedSpace',
-      format: 'format',
-      ejectable: 'ejectable',
-    })
+    .returnAsJson(
+      'volumesList',
+      {
+        name: 'name',
+        capacity: 'capacity',
+        freeSpace: 'freeSpace',
+        usedSpace: 'usedSpace',
+        format: 'format',
+        ejectable: 'ejectable',
+      },
+      // Match the tryCatch above: a disk we cannot serialize is skipped,
+      // not fatal to the whole enumeration.
+      { skipErrors: true },
+    )
     .endtell();
 
   return executeJsonScript<VolumeInfo[]>(script.build(), {

--- a/src/sources/windows.test.ts
+++ b/src/sources/windows.test.ts
@@ -161,6 +161,20 @@ describe('windows', () => {
       const result = await getAll();
       expect(result).toEqual([]);
     });
+
+    it('should serialize leniently so one unreadable window does not fail the batch', async () => {
+      mockExecute.mockResolvedValueOnce({
+        success: true,
+        output: '[]',
+        exitCode: 0,
+      });
+
+      await getAll();
+
+      const script = mockExecute.mock.calls[0][0];
+      const serializationLoop = script.slice(script.indexOf('set jsonParts to {}'));
+      expect(serializationLoop).toContain('try');
+    });
   });
 
   describe('getByApp', () => {

--- a/src/sources/windows.ts
+++ b/src/sources/windows.ts
@@ -70,18 +70,24 @@ export async function getAll(): Promise<WindowInfo[]> {
           ),
         ),
     )
-    .returnAsJson('windowsList', {
-      name: 'name',
-      app: 'app',
-      id: 'id',
-      x: 'x',
-      y: 'y',
-      width: 'width',
-      height: 'height',
-      minimized: 'minimized',
-      zoomed: 'zoomed',
-      visible: 'visible',
-    })
+    .returnAsJson(
+      'windowsList',
+      {
+        name: 'name',
+        app: 'app',
+        id: 'id',
+        x: 'x',
+        y: 'y',
+        width: 'width',
+        height: 'height',
+        minimized: 'minimized',
+        zoomed: 'zoomed',
+        visible: 'visible',
+      },
+      // Match the tryCatch above: a window we cannot serialize is skipped,
+      // not fatal to the whole enumeration.
+      { skipErrors: true },
+    )
     .endtell();
 
   const windows = await executeJsonScript<unknown[]>(script.build(), {

--- a/src/types.ts
+++ b/src/types.ts
@@ -448,6 +448,7 @@ export interface ScriptBuilder<TScope extends string = never, TReturn = unknown>
   returnAsJson: <TProperties extends Record<string, string>>(
     listVariable: string,
     propertyMap: TProperties,
+    options?: { skipErrors?: boolean },
   ) => ScriptBuilder<TScope, JsonObjectShape<TProperties>[]>;
   /**
    * Map a collection to JSON with automatic iteration, property extraction, and type inference.

--- a/src/types.ts
+++ b/src/types.ts
@@ -429,6 +429,9 @@ export interface ScriptBuilder<TScope extends string = never, TReturn = unknown>
    * @template TProperties - Property map type (inferred)
    * @param listVariable - Variable containing the list of records
    * @param propertyMap - Mapping of JSON keys to AppleScript properties
+   * @param options.skipErrors - When true, records that fail to serialize are omitted
+   * from the array. Defaults to false, so a failing record raises the underlying
+   * AppleScript error rather than disappearing from the result.
    * @returns Builder with return type set to Array<JsonObjectShape<TProperties>>
    *
    * @example
@@ -444,6 +447,10 @@ export interface ScriptBuilder<TScope extends string = never, TReturn = unknown>
    * // Type is inferred as: Array<{ id: string; name: string; email: string }>
    * const result = await runScript(script);
    * result.output[0].name; // TypeScript knows 'name' exists!
+   *
+   * @example
+   * // Tolerate individual records that cannot be serialized
+   * .returnAsJson('results', { id: 'id', name: 'name' }, { skipErrors: true })
    */
   returnAsJson: <TProperties extends Record<string, string>>(
     listVariable: string,


### PR DESCRIPTION
## Problem

`returnAsJson()` wrapped each record's serialization in a bare AppleScript `try` with no catch, so any record that failed property access vanished from the result array with **no signal at all**. `ScriptExecutor.execute` discards stderr on success (`src/executor.ts`), so an AppleScript `log` could not have surfaced it either.

This was also inconsistent: `mapToJson()` already had an opt-in `skipErrors` flag defaulting to *off*, but it then handed off to `returnAsJson`, which swallowed unconditionally regardless.

## Change

- `returnAsJson(listVariable, propertyMap, options?)` accepts `{ skipErrors?: boolean }`, defaulting to `false`. No `try` is emitted, so a failing record raises the real AppleScript error and `result.success` is `false`.
- `mapToJson` threads its existing `skipErrors` through, so one flag now governs both record building and serialization.

## Evidence

Probe added as `scripts/debug-json-skip.ts` — three records where the middle one lacks a mapped property:

- default: `success: false`, `Can't get label of {id:2}. (-1728)`
- `skipErrors: true`: `success: true`, `[{"id":1,...},{"id":3,...}]` — the old silent drop, now explicitly requested

Real-world check: `examples/list-applications.ts` ran clean 3x under the stricter default; a counting probe showed 13/13 windows serializing.

## Breaking change

Callers relying on lenient serialization must now pass `{ skipErrors: true }`. Documented in CHANGELOG.md.

## Verification

- 859 tests pass (3 new covering both modes and the `mapToJson` threading)
- `tsc --noEmit` and eslint clean