### PR TITLE
refactor(builder): move createScript out of the package barrel, drop dead shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ All notable changes to applescript-node are documented in this file.
   behaviour of returning partial results when an individual window,
   process, or disk cannot be read.
 
+#### Maintenance
+
+- Moved `createScript` from `index.ts` into `builder.ts`, alongside the
+  `AppleScriptBuilder` it constructs. This removes three import cycles
+  between the package barrel and the `sources/` modules, which had to
+  import `createScript` back out of the barrel. The public API is
+  unchanged — `index.ts` already re-exports everything from `builder.ts`.
+- Removed the unused `src/bun.ts` and `src/node.ts` re-export shims. The
+  `./bun` and `./node` package entry points are served by `index.bun.ts`
+  and `index.node.ts`; these two files had no importers.
+
 ### 25 March 2026
 
 #### New Features

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -2440,3 +2440,14 @@ export class AppleScriptBuilder implements ScriptBuilder {
     return this;
   }
 }
+
+/**
+ * Create a new AppleScript builder.
+ * Preferred entry point for the fluent API — equivalent to `new AppleScriptBuilder()`.
+ *
+ * @example
+ * import { createScript, runScript } from 'applescript-node';
+ * const script = createScript().tell('Finder').get('name of front window').endtell();
+ * const result = await runScript(script);
+ */
+export const createScript = (): AppleScriptBuilder => new AppleScriptBuilder();

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -1,1 +1,0 @@
-export { runtime } from './runtime/bun.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { AppleScriptBuilder } from './builder.js';
 import { ScriptExecutor } from './executor.js';
 import type { OsaScriptOptions, Prettify, ScriptBuilder, ScriptExecutionResult } from './types.js';
 
@@ -35,8 +34,6 @@ export type {
   WindowInfo,
 } from './types.js';
 export * from './validator.js';
-
-export const createScript = () => new AppleScriptBuilder();
 
 export function runScript<TScope extends string, TReturn>(
   script: ScriptBuilder<TScope, TReturn>,

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,1 +1,0 @@
-export { runtime } from './runtime/node.js';

--- a/src/sources/applications.ts
+++ b/src/sources/applications.ts
@@ -1,5 +1,5 @@
+import { createScript } from '../builder.js';
 import { ScriptExecutor } from '../executor.js';
-import { createScript } from '../index.js';
 import { executeJsonScript, executeScriptOrThrow } from './shared.js';
 
 /**

--- a/src/sources/system.ts
+++ b/src/sources/system.ts
@@ -1,5 +1,5 @@
+import { createScript } from '../builder.js';
 import { ScriptExecutor } from '../executor.js';
-import { createScript } from '../index.js';
 import { executeJsonScript } from './shared.js';
 
 /**

--- a/src/sources/windows.ts
+++ b/src/sources/windows.ts
@@ -1,5 +1,5 @@
+import { createScript } from '../builder.js';
 import { ScriptExecutor } from '../executor.js';
-import { createScript } from '../index.js';
 import { executeJsonScript } from './shared.js';
 
 /**


### PR DESCRIPTION
Found by a `resect` audit of `src/`.

## Import cycles (3 → 0)

`sources/{applications,system,windows}.ts` each imported `createScript` from `'../index.js'` — but `createScript` was *declared in `index.ts` itself*, so every source module imported the package barrel back:

```
index.ts -> sources/index.ts -> sources/<mod>.ts -> index.ts
```

Moved `createScript` beside the `AppleScriptBuilder` it constructs. `index.ts` already does `export * from './builder.js'`, so **the public API is unchanged** and no new barrel entry was needed.

## Dead files removed

`src/bun.ts` and `src/node.ts` were one-line re-export shims with zero importers. Verified against all four places they could have been live:

- not in `package.json` `exports` (`./bun` and `./node` map to `dist/index.bun.*` / `dist/index.node.*`)
- not in tsup's `entry` (`index.ts`, `index.node.ts`, `index.bun.ts`)
- no references anywhere in `src/`, `examples/`, `scripts/`, `.github/`

`src/runtime/bun.ts` and `src/runtime/node.ts` stay reachable through `register-bun.ts` / `register-node.ts`, so nothing was orphaned.

## Verification

- `resect audit`: cycles 3 → 0, `index.ts` fan-in 5 → 2, orphan files 2 → 0, dead exports 2 → 0
- `tsc --noEmit` clean, `eslint .` clean
- 856 tests pass
- `tsup` build emits all three entry points; smoke-tested `createScript` from `dist/index.mjs` and confirmed it still builds script text