### PR TITLE
fix(helpers): parse diagnostics under the Bun runtime too

### DIFF
--- a/scripts/debug-bun-runtime-error.ts
+++ b/scripts/debug-bun-runtime-error.ts
@@ -1,0 +1,36 @@
+/**
+ * Does a failed run look the same under the Bun runtime as under Node's?
+ *
+ * The Node runtime goes through promisify(child_process.exec), which prefixes
+ * the thrown message with `Command failed: <cmd>`. The Bun runtime throws the
+ * raw stderr instead. Anything parsing that text has to cope with both, so this
+ * probe prints exactly what each shape is.
+ *
+ * Run: bun scripts/debug-bun-runtime-error.ts
+ */
+
+import { runScript } from '../src/index.bun.js';
+import { parseAppleScriptError } from '../src/helpers.js';
+
+console.log('=== live run under the Bun runtime ===');
+const result = await runScript('tell application "NoSuchApp" to activate');
+console.log('success:', result.success, ' exitCode:', result.exitCode);
+
+if (!result.success) {
+  const lines = result.error.split('\n');
+  console.log('error lines:', lines.length);
+  lines.forEach((line, index) => {
+    console.log(`  [${index}] ${JSON.stringify(line)}`);
+  });
+  console.log('has "Command failed:" preamble:', result.error.startsWith('Command failed:'));
+  console.log('parsed:', parseAppleScriptError(result.error), '  <-- expected a diagnostic');
+}
+
+console.log('\n=== both shapes through the parser ===');
+const diagnostic = '32:40: execution error: Can’t get application "NoSuchApp". (-1728)';
+
+const nodeShape = `Command failed: osascript -s h -e 'x'\n${diagnostic}\n`;
+console.log('node shape  ->', parseAppleScriptError(nodeShape)?.errorNumber, ' <-- expected -1728');
+
+const bunShape = `${diagnostic}\n`;
+console.log('bun shape   ->', parseAppleScriptError(bunShape)?.errorNumber, ' <-- expected -1728');

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -40,6 +40,23 @@ describe('toAppleScriptLiteral', () => {
     expect(toAppleScriptLiteral(['a', 1])).toBe('{"a", 1}');
     expect(toAppleScriptLiteral({ name: 'Finder', open: true })).toBe('{name:"Finder", open:true}');
   });
+
+  /**
+   * `undefined` is outside AppleScriptValue, so TypeScript callers cannot reach
+   * these, but plain-JS consumers and absent optional properties can — and
+   * without a guard they fall through to Object.entries(undefined) and throw.
+   */
+  it('treats undefined as missing value rather than throwing', () => {
+    expect(toAppleScriptLiteral(undefined)).toBe('missing value');
+    expect(toAppleScriptLiteral({ name: 'Finder', note: undefined })).toBe(
+      '{name:"Finder", note:missing value}',
+    );
+    expect(toAppleScriptLiteral(['a', undefined])).toBe('{"a", missing value}');
+  });
+
+  it('interpolates undefined into osa as missing value', () => {
+    expect(osa`set x to ${undefined}`).toBe('set x to missing value');
+  });
 });
 
 describe('osa', () => {
@@ -146,6 +163,42 @@ describe('parseAppleScriptError', () => {
     expect(
       parseAppleScriptError(`Command failed: osascript -s h -e 'log "execution error: nope (-1)"'`),
     ).toBeUndefined();
+  });
+
+  /**
+   * The Node runtime throws through promisify(exec), which prefixes the message
+   * with `Command failed: <command>`. The Bun runtime throws the raw stderr, so
+   * the diagnostic is line 0 with nothing before it.
+   */
+  it('parses the Bun runtime shape, which has no command preamble', () => {
+    const parsed = parseAppleScriptError(
+      '32:40: execution error: Can’t get application "NoSuchApp". (-1728)\n',
+    );
+    expect(parsed?.errorNumber).toBe(-1728);
+    expect(parsed?.message).toBe('Can’t get application "NoSuchApp".');
+  });
+
+  it('parses the Bun shape for a script whose source spans lines', () => {
+    const parsed = parseAppleScriptError('6:26: execution error: deliberate failure (42)\n');
+    expect(parsed?.errorNumber).toBe(42);
+  });
+
+  it('finds the diagnostic when the command echo spans several lines', () => {
+    const parsed = parseAppleScriptError(
+      [
+        `Command failed: osascript -s h -e 'tell application "Finder"`,
+        '  get bogus property',
+        `end tell'`,
+        '32:40: execution error: Can’t get bogus property. (-1728)',
+        '',
+      ].join('\n'),
+    );
+    expect(parsed?.errorNumber).toBe(-1728);
+    expect(parsed?.message).toBe('Can’t get bogus property.');
+  });
+
+  it('returns undefined for the Bun runtime fallback message', () => {
+    expect(parseAppleScriptError('Command failed with exit code 1')).toBeUndefined();
   });
 });
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -40,15 +40,21 @@ export function escapeAppleScriptString(str: string): string {
 /**
  * Convert a JavaScript value into its AppleScript literal form.
  *
- * Strings become quoted literals, `null` becomes `missing value`, arrays become
- * AppleScript lists, and plain objects become records.
+ * Strings become quoted literals, arrays become AppleScript lists, and plain
+ * objects become records. Both `null` and `undefined` become `missing value` —
+ * `undefined` is outside `AppleScriptValue`, but it reaches this function from
+ * plain-JS callers and from optional properties that are absent at runtime, and
+ * `missing value` is what AppleScript calls the same idea. Without the guard
+ * those cases fall through to the record branch and throw from
+ * `Object.entries(undefined)`.
  *
  * @example
  * toAppleScriptLiteral(['a', 1, true]); // '{"a", 1, true}'
  * toAppleScriptLiteral({ name: 'Finder' }); // '{name:"Finder"}'
+ * toAppleScriptLiteral({ name: 'Finder', note: undefined }); // '{name:"Finder", note:missing value}'
  */
-export function toAppleScriptLiteral(value: AppleScriptValue): string {
-  if (value === null) return 'missing value';
+export function toAppleScriptLiteral(value: AppleScriptValue | undefined): string {
+  if (value === null || value === undefined) return 'missing value';
   if (typeof value === 'string') return `"${escapeAppleScriptString(value)}"`;
   if (typeof value === 'number' || typeof value === 'boolean') return String(value);
   if (Array.isArray(value)) return `{${value.map((v) => toAppleScriptLiteral(v)).join(', ')}}`;
@@ -69,7 +75,10 @@ export function toAppleScriptLiteral(value: AppleScriptValue): string {
  * const script = osa`tell application ${name} to get name of front window`;
  * // tell application "Finder" to get name of front window
  */
-export function osa(strings: TemplateStringsArray, ...values: AppleScriptValue[]): string {
+export function osa(
+  strings: TemplateStringsArray,
+  ...values: (AppleScriptValue | undefined)[]
+): string {
   return strings.reduce(
     (acc, part, index) =>
       index === 0 ? part : `${acc}${toAppleScriptLiteral(values[index - 1])}${part}`,
@@ -135,17 +144,26 @@ const normaliseNewlines = (message: string): string => message.replace(/\r\n?/g,
 /**
  * Pull the structured diagnostic out of a failed run's error text.
  *
- * osascript writes the shell command on the first line and its own diagnostic
- * after it, so the first line is skipped. Returns `undefined` when no line has
- * the diagnostic shape — a missing script file, for instance, reports
- * `osascript: <path>: No such file or directory` and nothing else.
+ * The two runtimes hand us different shapes. Node's `promisify(exec)` prefixes
+ * the thrown message with `Command failed: <command>` and puts the diagnostic
+ * after it; Bun throws the raw stderr, so the diagnostic is the very first line.
+ * Rather than assume a position, drop the command echo and scan what remains
+ * from the end — the diagnostic always trails the command it describes, and a
+ * script whose own source happens to contain `... error: ... (-1)` cannot be
+ * mistaken for it.
+ *
+ * Returns `undefined` when no line has the diagnostic shape — a missing script
+ * file, for instance, reports `osascript: <path>: No such file or directory`.
  *
  * @example
  * const diagnostic = parseAppleScriptError(result.error);
  * if (diagnostic?.errorNumber === -1728) { ... }
  */
 export function parseAppleScriptError(errorText: string): AppleScriptDiagnostic | undefined {
-  const lines = errorText.split('\n').slice(1);
+  const lines = errorText
+    .split('\n')
+    .filter((line) => !line.startsWith('Command failed:'))
+    .reverse();
 
   for (const line of lines) {
     const trimmed = line.trim();


### PR DESCRIPTION
Follow-up to #88, addressing its review. Both findings were raised there after the merge.

## The bug

`parseAppleScriptError` dropped the first line unconditionally, assuming the `Command failed: <command>` preamble that Node's `promisify(child_process.exec)` prepends. The Bun runtime (`src/runtime/bun.ts`) throws the raw stderr instead, so line 0 **is** the diagnostic — and `slice(1)` discarded it.

Confirmed on the real Bun path rather than by reading, via `bun scripts/debug-bun-runtime-error.ts`:

```
=== live run under the Bun runtime ===
error lines: 2
  [0] "32:40: execution error: Can't get application \"NoSuchApp\". (-1728)"
  [1] ""
has "Command failed:" preamble: false
parsed: undefined   <-- expected a diagnostic
```

`applescript-node/bun` is a published entry point, so consumers using it got `diagnostic` and `errorNumber` as `undefined` every time — silently defeating the "branch on `errorNumber` instead of message text" feature that #88 was for. `message` still fell back to the full stderr, so nothing was lost visibly, which is what made it silent.

## The fix

Drop the command echo by prefix and scan what remains **from the end**. The diagnostic always trails the command it describes, so this handles both runtimes without depending on line position. It also fixes a case neither runtime forced: when a multi-line script makes the command echo span several lines, the diagnostic is no longer missed.

Scanning backwards keeps the existing protection too — a script whose own source contains `... error: ... (-1)` still cannot be mistaken for a real diagnostic, because the real one is found first.

## Also

`toAppleScriptLiteral` now treats `undefined` as `missing value`. It sits outside `AppleScriptValue`, so TypeScript callers cannot reach it, but plain-JS consumers and optional properties that are absent at runtime can — and it previously fell through to the record branch and threw from `Object.entries(undefined)`. `missing value` is what AppleScript calls the same idea, so the mapping is the honest one rather than a guard that throws more politely.

## Testing

- 898 tests pass, up 6: the Bun shape (no preamble), a multi-line command echo, the Bun fallback message, and the `undefined` cases
- The existing "ignores the command line" test still passes, so the false-positive protection is intact
- `eslint` and `tsc --noEmit` clean, including under the file-list form the pre-commit hook uses
- `scripts/debug-bun-runtime-error.ts` is committed so the runtime difference can be re-checked