### PR TITLE
fix(sources): repair hide/show, and make AppleScript escaping a single implementation

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,5 +1,6 @@
 import { resolveExpression } from './builder-utils.js';
 import { ExprBuilder } from './expressions.js';
+import { escapeAppleScriptString, toAppleScriptLiteral } from './literals.js';
 import type { AppleScriptValue, JsonObjectShape, ScriptBuilder } from './types.js';
 
 type BlockType =
@@ -30,33 +31,20 @@ export class AppleScriptBuilder implements ScriptBuilder {
     return this.INDENT.repeat(this.indentLevel);
   }
 
+  // Escaping and literal formatting live in literals.ts so the builder, the
+  // sources/* modules, and the top-level helpers cannot drift apart. These stay
+  // as private methods because they are called throughout the class body.
+
   private escapeString(str: string): string {
-    // In AppleScript, backslashes and quotes need to be escaped
-    // Also handle common escape sequences
-    return str
-      .replace(/\\/g, '\\\\') // Backslash
-      .replace(/"/g, '\\"') // Quote
-      .replace(/\n/g, '\\n') // Newline
-      .replace(/\r/g, '\\r') // Carriage return
-      .replace(/\t/g, '\\t'); // Tab
+    return escapeAppleScriptString(str);
   }
 
   private formatValue(value: AppleScriptValue): string {
-    if (value === null) return 'missing value';
-    if (typeof value === 'string') return `"${this.escapeString(value)}"`;
-    if (typeof value === 'number') return value.toString();
-    if (typeof value === 'boolean') return value.toString();
-    if (Array.isArray(value)) {
-      return `{${value.map((v) => this.formatValue(v)).join(', ')}}`;
-    }
-    return this.makeRecord(value as Record<string, AppleScriptValue>);
+    return toAppleScriptLiteral(value);
   }
 
   private makeRecord(properties: Record<string, AppleScriptValue>): string {
-    const entries = Object.entries(properties)
-      .map(([k, v]) => `${k}:${this.formatValue(v)}`)
-      .join(', ');
-    return `{${entries}}`;
+    return toAppleScriptLiteral(properties);
   }
 
   private validateBlockStack(): void {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,6 +10,7 @@
 
 import { AppleScriptBuilder } from './builder.js';
 import { ScriptExecutor } from './executor.js';
+import { toAppleScriptLiteral } from './literals.js';
 import type {
   AppleScriptDiagnostic,
   AppleScriptValue,
@@ -19,51 +20,10 @@ import type {
   ScriptExecutionResult,
 } from './types.js';
 
-/**
- * Escape a JavaScript string for safe embedding inside an AppleScript string literal.
- *
- * Backslashes are escaped first, then quotes, so an input backslash never combines
- * with a following quote to produce an unterminated literal.
- *
- * @example
- * escapeAppleScriptString('say "hi"\\now'); // 'say \\"hi\\"\\\\now'
- */
-export function escapeAppleScriptString(str: string): string {
-  return str
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t');
-}
-
-/**
- * Convert a JavaScript value into its AppleScript literal form.
- *
- * Strings become quoted literals, arrays become AppleScript lists, and plain
- * objects become records. Both `null` and `undefined` become `missing value` —
- * `undefined` is outside `AppleScriptValue`, but it reaches this function from
- * plain-JS callers and from optional properties that are absent at runtime, and
- * `missing value` is what AppleScript calls the same idea. Without the guard
- * those cases fall through to the record branch and throw from
- * `Object.entries(undefined)`.
- *
- * @example
- * toAppleScriptLiteral(['a', 1, true]); // '{"a", 1, true}'
- * toAppleScriptLiteral({ name: 'Finder' }); // '{name:"Finder"}'
- * toAppleScriptLiteral({ name: 'Finder', note: undefined }); // '{name:"Finder", note:missing value}'
- */
-export function toAppleScriptLiteral(value: AppleScriptValue | undefined): string {
-  if (value === null || value === undefined) return 'missing value';
-  if (typeof value === 'string') return `"${escapeAppleScriptString(value)}"`;
-  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-  if (Array.isArray(value)) return `{${value.map((v) => toAppleScriptLiteral(v)).join(', ')}}`;
-
-  const entries = Object.entries(value as Record<string, AppleScriptValue>)
-    .map(([key, val]) => `${key}:${toAppleScriptLiteral(val)}`)
-    .join(', ');
-  return `{${entries}}`;
-}
+// Escaping and literal formatting are defined in literals.ts, which the builder
+// and the sources/* modules import too. Re-exported here because they are part
+// of this module's published surface.
+export { escapeAppleScriptString, toAppleScriptLiteral } from './literals.js';
 
 /**
  * Tagged template that builds an AppleScript source string with safely escaped
@@ -303,31 +263,32 @@ export async function tell<T = string>(
 /**
  * Activate (bring to the front) the named application.
  *
+ * @throws {ScriptExecutionError} If osascript reports a failure — most often
+ * error `-1728` when no such application exists.
+ *
  * @example
  * await activate('Safari');
  */
 export async function activate(application: string): Promise<void> {
-  const script = osa`tell application ${application} to activate`;
-  const result = await ScriptExecutor.execute(script);
-
-  if (!result.success) {
-    throw new ScriptExecutionError(result.error, result.exitCode, script);
-  }
+  await runScriptOrThrow(osa`tell application ${application} to activate`);
 }
 
 /**
  * Report whether the named application is currently running, without launching it.
  *
+ * The check goes through System Events rather than the application itself,
+ * because addressing an app directly would launch it to answer the question.
+ *
+ * @throws {ScriptExecutionError} If osascript reports a failure, for instance
+ * when System Events has not been granted automation access.
+ *
  * @example
  * if (await isRunning('Music')) { ... }
  */
 export async function isRunning(application: string): Promise<boolean> {
-  const script = osa`tell application "System Events" to (name of processes) contains ${application}`;
-  const result = await ScriptExecutor.execute(script);
+  const output = await runScriptOrThrow(
+    osa`tell application "System Events" to (name of processes) contains ${application}`,
+  );
 
-  if (!result.success) {
-    throw new ScriptExecutionError(result.error, result.exitCode, script);
-  }
-
-  return result.output?.trim() === 'true';
+  return output.trim() === 'true';
 }

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -1,0 +1,62 @@
+/**
+ * AppleScript literal formatting — the single implementation of "turn a
+ * JavaScript value into AppleScript source text".
+ *
+ * This lives on its own rather than in `helpers.ts` because `helpers.ts` imports
+ * the builder (for `tell`), so the builder cannot import back without recreating
+ * the cycle removed in #87. Everything that needs to escape a value — the
+ * builder, the `sources/*` modules, and the top-level helpers — imports from
+ * here, so the escaping rules cannot drift between them.
+ *
+ * @module literals
+ */
+
+import type { AppleScriptValue } from './types.js';
+
+/**
+ * Escape a JavaScript string for safe embedding inside an AppleScript string literal.
+ *
+ * Backslashes are escaped first, then quotes, so an input backslash never
+ * combines with a following quote to produce an unterminated literal. Escaping
+ * quotes first is the classic bug: `a\"b` would become `a\\"b`, whose `\\` is a
+ * literal backslash, leaving the `"` to terminate the string.
+ *
+ * @example
+ * escapeAppleScriptString('say "hi"\\now'); // 'say \\"hi\\"\\\\now'
+ */
+export function escapeAppleScriptString(str: string): string {
+  return str
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}
+
+/**
+ * Convert a JavaScript value into its AppleScript literal form.
+ *
+ * Strings become quoted literals, arrays become AppleScript lists, and plain
+ * objects become records. Both `null` and `undefined` become `missing value` —
+ * `undefined` is outside `AppleScriptValue`, but it reaches this function from
+ * plain-JS callers and from optional properties that are absent at runtime, and
+ * `missing value` is what AppleScript calls the same idea. Without the guard
+ * those cases fall through to the record branch and throw from
+ * `Object.entries(undefined)`.
+ *
+ * @example
+ * toAppleScriptLiteral(['a', 1, true]); // '{"a", 1, true}'
+ * toAppleScriptLiteral({ name: 'Finder' }); // '{name:"Finder"}'
+ * toAppleScriptLiteral({ name: 'Finder', note: undefined }); // '{name:"Finder", note:missing value}'
+ */
+export function toAppleScriptLiteral(value: AppleScriptValue | undefined): string {
+  if (value === null || value === undefined) return 'missing value';
+  if (typeof value === 'string') return `"${escapeAppleScriptString(value)}"`;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) return `{${value.map((v) => toAppleScriptLiteral(v)).join(', ')}}`;
+
+  const entries = Object.entries(value as Record<string, AppleScriptValue>)
+    .map(([key, val]) => `${key}:${toAppleScriptLiteral(val)}`)
+    .join(', ');
+  return `{${entries}}`;
+}

--- a/src/sources/applications.test.ts
+++ b/src/sources/applications.test.ts
@@ -401,9 +401,48 @@ describe('applications', () => {
       await hide('App with "quotes"');
 
       const scriptCall = mockExecute.mock.calls.at(-1);
-      // The script contains: process "App with \"quotes\""
-      // In the string representation, backslashes are escaped, so we check for the escaped version
-      expect(scriptCall?.[0]).toMatch(/App with .*quotes/);
+      expect(scriptCall?.[0]).toContain(
+        String.raw`set visible of process "App with \"quotes\"" to false`,
+      );
+    });
+
+    /**
+     * The name must be escaped exactly once. The previous nested-tell form fed
+     * an already-escaped name back through the builder's own escaping, so a
+     * single quote arrived as `\\\"` in the emitted script.
+     */
+    it('should address the app as a process inside System Events', async () => {
+      mockExecute.mockResolvedValueOnce({
+        success: true,
+        output: '',
+        exitCode: 0,
+      });
+
+      await hide('Safari');
+
+      const scriptCall = mockExecute.mock.calls.at(-1);
+      expect(scriptCall?.[0]).toContain('set visible of process "Safari" to false');
+      expect(scriptCall?.[0]).not.toContain('tell application "process');
+    });
+
+    /**
+     * Escaping quotes without escaping backslashes first leaves `a\"b` as
+     * `a\\"b`, whose `\\` is a literal backslash — so the `"` terminates the
+     * string and the rest of the name becomes code. Verified against live
+     * osascript: the unescaped form fails with "Expected \" but found unknown
+     * token. (-2741)".
+     */
+    it('should escape backslashes before quotes in app name', async () => {
+      mockExecute.mockResolvedValueOnce({
+        success: true,
+        output: '',
+        exitCode: 0,
+      });
+
+      await hide(String.raw`back\slash"quote`);
+
+      const scriptCall = mockExecute.mock.calls.at(-1);
+      expect(scriptCall?.[0]).toContain(String.raw`process "back\\slash\"quote"`);
     });
   });
 

--- a/src/sources/applications.ts
+++ b/src/sources/applications.ts
@@ -1,5 +1,6 @@
 import { createScript } from '../builder.js';
 import { ScriptExecutor } from '../executor.js';
+import { escapeAppleScriptString } from '../literals.js';
 import { executeJsonScript, executeScriptOrThrow } from './shared.js';
 
 /**
@@ -205,16 +206,20 @@ export async function show(appName: string): Promise<void> {
   await setApplicationVisibility(appName, true);
 }
 
-function escapeAppleScriptString(value: string): string {
-  return value.replace(/"/g, '\\"');
-}
-
+/**
+ * Build the script that shows or hides an application.
+ *
+ * The target must be addressed as a process *inside* System Events. Passing
+ * `process "X"` to the builder's `tell()` produced
+ * `tell application "process \"X\""` — a nested application lookup that always
+ * failed with `-1728`, and which double-escaped the name on the way. Verified
+ * against live osascript: that form errors with
+ * `Can't get application "process \"Finder\""`, while this one returns.
+ */
 function buildVisibilityScript(appName: string, visible: boolean): string {
   const script = createScript()
     .tell('System Events')
-    .tell(`process "${escapeAppleScriptString(appName)}"`)
-    .raw(`set visible to ${visible}`)
-    .endtell()
+    .raw(`set visible of process "${escapeAppleScriptString(appName)}" to ${visible}`)
     .endtell();
 
   return script.build();


### PR DESCRIPTION
Addresses the remaining findings from the review of #88, plus a broken code path that fixing them exposed.

## `hide()` and `show()` never worked

`buildVisibilityScript` passed `process "X"` to the builder's `tell()`, which wraps its target as `tell application "<target>"`. The emitted script was:

```applescript
tell application "System Events"
  tell application "process \"Safari\""
    set visible to false
```

That is a nested *application* lookup, so every call failed. Verified against live osascript rather than inferred:

```
current    : FAILED -> execution error: Can't get application "process \"Finder\"". (-1728)
alternative: SUCCESS output="true"
```

The unit tests passed throughout because they mock the executor and never run a script — and the one escaping assertion used a loose `/App with .*quotes/` regex that matched the mangled output just as happily as correct output. Tests now assert the emitted script exactly.

## Escaping was duplicated, and one copy was wrong

`sources/applications.ts` had its own `escapeAppleScriptString` that escaped quotes but **not** backslashes — the reverse of the ordering CLAUDE.md documents. `a\"b` became `a\\"b`, whose `\\` is a literal backslash, leaving the quote free to terminate the string. Live osascript rejects it:

```
input: backslash\before"quote
local    : WRONG -> syntax error: Expected "\"" but found unknown token. (-2741)
canonical: OK    -> backslash\before"quote
```

I did not demonstrate code execution through that path — the crafted payload errored rather than executing — but it breaks on any name containing a backslash. The same name was also being escaped twice, once locally and again by the builder.

`helpers.ts` separately duplicated `AppleScriptBuilder`'s private `escapeString`/`formatValue`/`makeRecord` line for line.

**Fix:** a new `src/literals.ts` holds the canonical implementations and imports only types. The builder, the helpers, and `sources/*` all import from it. It could not live in `helpers.ts`, because `helpers.ts` imports `builder.js` for `tell()` — importing back would rebuild exactly the cycle #87 removed. `helpers.ts` re-exports both functions, so the published surface is unchanged.

## Also

`activate`/`isRunning` now route through `runScriptOrThrow` instead of repeating its throw logic, and both document that they throw `ScriptExecutionError`.

## Testing

- 900 tests pass, up 2; the builder's 211 tests are the evidence that delegating its private methods preserved behaviour
- New assertions cover backslash-before-quote escaping and the process addressing, both of which fail against the previous implementation
- Fixed addressing confirmed against live osascript, not just against mocks
- `eslint` and `tsc --noEmit` clean